### PR TITLE
Empty and without versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Do not forget to include:
 ## Added
 - Version metadata, see: `./postgres/initdb/04-add-version-metadata-table.sql`
 
+## Changed
+- Set `shm_size` in docker-compose setup to increase default 64mb limit 
+
+## Fixed
+- Continue indexing by indexer when bumping into a file without versions
+
 [v1.12.1]
 ### Fixed
 - Show commit and tag name in textrepo-app and about images using docker build hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Do not forget to include:
 
 ## Fixed
 - Continue indexing by indexer when bumping into a file without versions
-- Autocomplete indexer can handle empty files 
+- Autocomplete and full-text indexers can handle empty files now 
 
 [v1.12.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Do not forget to include:
 
 ## Fixed
 - Continue indexing by indexer when bumping into a file without versions
+- Autocomplete indexer can handle empty files 
 
 [v1.12.1]
 ### Fixed

--- a/elasticsearch/full-text/src/main/java/nl/knaw/huc/service/FieldsService.java
+++ b/elasticsearch/full-text/src/main/java/nl/knaw/huc/service/FieldsService.java
@@ -13,6 +13,7 @@ import org.apache.tika.sax.BodyContentHandler;
 import org.xml.sax.SAXException;
 
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.BadRequestException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -59,13 +60,16 @@ public class FieldsService {
 
   private Fields parseWithTika(InputStream inputStream, AbstractParser parser) {
     var bytes = getBytes(inputStream);
+    if (bytes.length == 0) {
+      return new Fields("");
+    }
     var metadata = new Metadata();
     var parseContext = new ParseContext();
     var handler = new BodyContentHandler(-1);
     try {
       parser.parse(new ByteArrayInputStream(bytes), handler, metadata, parseContext);
     } catch (IOException | SAXException | TikaException ex) {
-      throw new IllegalArgumentException("Could not parse file using tika", ex);
+      throw new BadRequestException("Could not parse file using tika", ex);
     }
     return new Fields(handler.toString());
   }
@@ -75,7 +79,7 @@ public class FieldsService {
     try {
       copy(xml, baos);
     } catch (IOException ex) {
-      throw new IllegalStateException("Could not copy inputstream", ex);
+      throw new BadRequestException("Could not copy inputstream", ex);
     }
     return baos.toByteArray();
   }

--- a/examples/development/docker-compose.env
+++ b/examples/development/docker-compose.env
@@ -1,10 +1,15 @@
+# immitate commit hash variable, as set by dockerhub:
 export SOURCE_COMMIT=$(git rev-parse HEAD)
+
+# immitate docker tag name, as set by dockerhub:
 export DOCKER_TAG=latest
 
+# about page description and links
 export ABOUT_TR_DESCRIPTION='Text Repository Dev'
 export ABOUT_TR_SOURCECODE='https://github.com/knaw-huc/textrepo'
 export ABOUT_TR_DOCUMENTATION='https://textrepo.readthedocs.io'
 
+# textrep-app variables
 export TR_DATABASE_DRIVER_CLASS=org.postgresql.Driver
 export TR_DATABASE_USER=textrepo
 export TR_DATABASE_PASSWORD=textrepo

--- a/textrepo-app/src/main/java/nl/knaw/huc/api/FormTextRepoFile.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/api/FormTextRepoFile.java
@@ -13,12 +13,12 @@ public class FormTextRepoFile {
   private UUID docId;
 
   @NotNull(message = "is mandatory")
-  private final short typeId;
+  private Short typeId;
 
   @JsonCreator
   public FormTextRepoFile(
       @JsonProperty("docId") UUID docId,
-      @JsonProperty("typeId") short typeId
+      @JsonProperty("typeId") Short typeId
   ) {
     this.docId = docId;
     this.typeId = typeId;

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/task/IndexResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/task/IndexResource.java
@@ -59,7 +59,7 @@ public class IndexResource {
 
   @POST
   @Path("/{name}")
-  @ApiOperation("Index all files of a single index")
+  @ApiOperation("Index or reindex single index with all relevant files, including those without versions")
   public Response indexSingleIndex(@PathParam("name") String name) {
     log.debug("Index all files of index: index={}", name);
     final var task = factory

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/task/GetLatestOptionalFileVersion.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/task/GetLatestOptionalFileVersion.java
@@ -1,0 +1,30 @@
+package nl.knaw.huc.service.task;
+
+import nl.knaw.huc.core.TextRepoFile;
+import nl.knaw.huc.core.Version;
+import nl.knaw.huc.db.VersionsDao;
+import org.jdbi.v3.core.Handle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class GetLatestOptionalFileVersion implements InTransactionProvider<Optional<Version>> {
+  private static final Logger log = LoggerFactory.getLogger(GetLatestOptionalFileVersion.class);
+
+  private final TextRepoFile file;
+
+  public GetLatestOptionalFileVersion(TextRepoFile file) {
+    this.file = requireNonNull(file);
+  }
+
+  @Override
+  public Optional<Version> executeIn(Handle transaction) {
+    return transaction
+        .attach(VersionsDao.class)
+        .findLatestByFileId(file.getId());
+  }
+
+}

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/task/GetLatestOptionalFileVersion.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/task/GetLatestOptionalFileVersion.java
@@ -7,6 +7,7 @@ import org.jdbi.v3.core.Handle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.BadRequestException;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;


### PR DESCRIPTION
TextRepo should continue indexing files when it encounters a file without versions.
Indexers should be able to index empty files without failing.