### PR TITLE
Mimetype subtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Do not forget to include:
 
 ## [Unreleased]
 
+### Changed
+- Autocomplete and full-text indexers now index "subtypes" of a mimetype as if they where that mimetype. E.g. pagexml of 'application/vnd.prima.page+xml' is indexed as ordinary xml or 'application/xml'. See `Added` for new env vars.
+
+### Added
+- Environment variables: AUTOCOMPLETE_XML_SUBTYPES, AUTOCOMPLETE_TXT_SUBTYPES, FULL_TEXT_XML_SUBTYPES, FULL_TEXT_TXT_SUBTYPES
+
 ## [1.13.1]
 
 ## Fixed

--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -65,3 +65,12 @@ Indexers and their ES indexes can be configured with ``$TR_INDEXERS`` in  ``dock
       hosts:
         -       # list of strings, host urls
 
+
+Default indexers
+----------------
+
+The textrepo contains a number of default indexers:
+
+- `Full-text indexer <https://github.com/knaw-huc/textrepo/tree/master/elasticsearch/full-text>`_: for basic full-text search queries
+- `Autocomplete indexer <https://github.com/knaw-huc/textrepo/tree/master/elasticsearch/autocomplete>`_: for autocomplete suggestions
+- `File indexer <https://github.com/knaw-huc/textrepo/tree/master/elasticsearch/file>`_: for searching the metadata of documents, files and versions

--- a/elasticsearch/autocomplete/Dockerfile
+++ b/elasticsearch/autocomplete/Dockerfile
@@ -7,7 +7,8 @@ FROM openjdk:11-jre-slim-stretch
 COPY --from=builder /build/target/autocomplete-1.0-SNAPSHOT.jar /indexer/autocomplete.jar
 
 WORKDIR /indexer
-COPY ./config.yml /indexer/
+RUN apt-get update && apt-get install -y gettext-base
+COPY ./config-template.yml /indexer/
 COPY ./autocomplete-mapping.json /indexer/
 COPY ./scripts/start.sh /indexer/
 

--- a/elasticsearch/autocomplete/README.md
+++ b/elasticsearch/autocomplete/README.md
@@ -17,3 +17,10 @@ Search in elasticsearch index by `<term>`:
 curl -X POST '<index-host>/_search' -H 'Content-Type:application/json' \
   -d '{"suggest":{"keyword-suggest":{"prefix":"<term>", "completion":{"field":"suggest","skip_duplicates":true,"size":5}}},"_source":false}'
 ```
+
+## Mimetypes and subtypes
+The autocomplete indexer knows about a number mimetypes.
+
+Besides those mimetypes the indexer has the concept of "mimetype subtypes", a configurable list of mimetypes that the autocomplete indexer will handle just like their "super" mimetype. E.g. pagexml or 'application/vnd.prima.page+xml' can be configured to be indexed just like ordinary xml or 'application/xml'.
+
+Check `<host>/autocomplete/types` for a list of mimetypes and their subtypes.

--- a/elasticsearch/autocomplete/config-template.yml
+++ b/elasticsearch/autocomplete/config-template.yml
@@ -5,4 +5,9 @@ logging:
     org.hibernate: ERROR
 minKeywordLength: 3
 keywordDelimiters: " \t\n\r\f,.:;?![]'="
+mimetypeSubtypes:
+  - mimetype: 'application/xml'
+    subtypes: ${AUTOCOMPLETE_XML_SUBTYPES}
+  - mimetype: 'text/plain'
+    subtypes: ${AUTOCOMPLETE_TXT_SUBTYPES}
 mappingFile: ./autocomplete-mapping.json

--- a/elasticsearch/autocomplete/scripts/start.sh
+++ b/elasticsearch/autocomplete/scripts/start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+envsubst < /indexer/config-template.yml > /indexer/config.yml
 
 java -jar /indexer/autocomplete.jar server config.yml

--- a/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/AutocompleteConfiguration.java
+++ b/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/AutocompleteConfiguration.java
@@ -5,6 +5,7 @@ import io.dropwizard.Configuration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 public class AutocompleteConfiguration extends Configuration {
 
@@ -19,6 +20,10 @@ public class AutocompleteConfiguration extends Configuration {
   @Valid
   @NotNull
   private String mappingFile;
+
+  @Valid
+  @NotNull
+  private List<MimetypeSubtypesConfiguration> mimetypeSubtypes;
 
   @JsonProperty("minKeywordLength")
   public int getMinKeywordLength() {
@@ -50,4 +55,13 @@ public class AutocompleteConfiguration extends Configuration {
     this.mappingFile = mappingFile;
   }
 
+  @JsonProperty("mimetypeSubtypes")
+  public List<MimetypeSubtypesConfiguration> getMimetypeSubtypes() {
+    return mimetypeSubtypes;
+  }
+
+  @JsonProperty("mimetypeSubtypes")
+  public void setMimetypeSubtypes(List<MimetypeSubtypesConfiguration> mimetypeSubtypes) {
+    this.mimetypeSubtypes = mimetypeSubtypes;
+  }
 }

--- a/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/AutocompleteIndexer.java
+++ b/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/AutocompleteIndexer.java
@@ -9,6 +9,7 @@ import nl.knaw.huc.health.MappingFileHealthCheck;
 import nl.knaw.huc.resources.AutocompleteResource;
 import nl.knaw.huc.service.FieldsService;
 import nl.knaw.huc.service.MappingService;
+import nl.knaw.huc.service.SubtypeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,8 @@ public class AutocompleteIndexer extends Application<AutocompleteConfiguration> 
   public void run(AutocompleteConfiguration config, Environment environment) {
     var contentsService = new FieldsService(config);
     var mappingService = new MappingService(config);
-    var contentsResource = new AutocompleteResource(contentsService, mappingService);
+    var subtypeService = new SubtypeService(config.getMimetypeSubtypes());
+    var contentsResource = new AutocompleteResource(contentsService, mappingService, subtypeService);
 
     environment.jersey().register(new IllegalMimetypeExceptionMapper());
     environment.jersey().register(contentsResource);

--- a/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/MimetypeSubtypesConfiguration.java
+++ b/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/MimetypeSubtypesConfiguration.java
@@ -1,0 +1,38 @@
+package nl.knaw.huc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+public class MimetypeSubtypesConfiguration {
+
+  @Valid
+  @NotNull
+  private String mimetype;
+
+  @Valid
+  @NotNull
+  private List<String> subtypes;
+
+  @JsonProperty("subtypes")
+  public List<String> getSubtypes() {
+    return subtypes;
+  }
+
+  @JsonProperty("subtypes")
+  public void setSubtypes(List<String> subtypes) {
+    this.subtypes = subtypes;
+  }
+
+  @JsonProperty("mimetype")
+  public String getMimetype() {
+    return mimetype;
+  }
+
+  @JsonProperty("mimetype")
+  public void setMimetype(String mimetype) {
+    this.mimetype = mimetype;
+  }
+}

--- a/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/api/MimetypeSubtypesResult.java
+++ b/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/api/MimetypeSubtypesResult.java
@@ -1,0 +1,42 @@
+package nl.knaw.huc.api;
+
+import nl.knaw.huc.MimetypeSubtypesConfiguration;
+import nl.knaw.huc.core.SupportedType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MimetypeSubtypesResult {
+
+  public List<MimetypeSubtypeResult> types = new ArrayList<>();
+
+  /**
+   * Merge SupportedTypes and mimetypeSubtypes into a single List< MimetypeSubtype >
+   */
+  public MimetypeSubtypesResult(List<MimetypeSubtypesConfiguration> mimetypeSubtypes) {
+    for (var mimetype : SupportedType.values()) {
+      var subtypes = mimetypeSubtypes
+          .stream()
+          .filter(st -> st.getMimetype().equals(mimetype.getMimetype()))
+          .map(MimetypeSubtypesConfiguration::getSubtypes)
+          .findFirst();
+
+      var typeResult = new MimetypeSubtypeResult(
+          mimetype.getMimetype(),
+          subtypes.orElse(new ArrayList<>())
+      );
+      types.add(typeResult);
+    }
+  }
+
+  public static class MimetypeSubtypeResult {
+    public String mimetype;
+    public List<String> subtypes;
+
+    public MimetypeSubtypeResult(String mimetype, List<String> subtypes) {
+
+      this.mimetype = mimetype;
+      this.subtypes = subtypes;
+    }
+  }
+}

--- a/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/core/SupportedType.java
+++ b/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/core/SupportedType.java
@@ -17,6 +17,10 @@ public enum SupportedType {
     this.mimetype = mimetype;
   }
 
+  public static boolean exists(String mimetype) {
+    return stream(values()).anyMatch(st -> st.mimetype.equals(mimetype));
+  }
+
   public String getMimetype() {
     return mimetype;
   }
@@ -27,9 +31,17 @@ public enum SupportedType {
         return supportedType;
       }
     }
-    throw new IllegalMimetypeException(format(
-        "Unexpected mimetype: got [%s] but should be one of [%s]",
-        mimetype, stream(values()).map(v -> "" + v.getMimetype()).collect(joining(", ")))
-    );
+    throw unexpectedMimetype(mimetype);
+  }
+
+  public static IllegalMimetypeException unexpectedMimetype(String mimetype) {
+    return new IllegalMimetypeException(format(
+        "Unexpected mimetype: got [%s] but should be one of [%s] or their subtypes",
+        mimetype, supported()
+    ));
+  }
+
+  private static String supported() {
+    return stream(values()).map(v -> "" + v.getMimetype()).collect(joining(", "));
   }
 }

--- a/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/service/SubtypeService.java
+++ b/elasticsearch/autocomplete/src/main/java/nl/knaw/huc/service/SubtypeService.java
@@ -1,0 +1,33 @@
+package nl.knaw.huc.service;
+
+import nl.knaw.huc.MimetypeSubtypesConfiguration;
+import nl.knaw.huc.core.SupportedType;
+
+import java.util.List;
+
+public class SubtypeService {
+
+  private final List<MimetypeSubtypesConfiguration> mimetypeSubtypes;
+
+  public SubtypeService(List<MimetypeSubtypesConfiguration> mimetypeSubtypes) {
+    this.mimetypeSubtypes = mimetypeSubtypes;
+  }
+
+  public SupportedType determine(String mimetype) {
+    if (SupportedType.exists(mimetype)) {
+      return SupportedType.fromString(mimetype);
+    }
+
+    for (var mimetypeSubtype : mimetypeSubtypes) {
+      if (mimetypeSubtype.getSubtypes().contains(mimetype)) {
+        return SupportedType.fromString(mimetypeSubtype.getMimetype());
+      }
+    }
+
+    throw SupportedType.unexpectedMimetype(mimetype);
+  }
+
+  public List<MimetypeSubtypesConfiguration> getMimetypeSubtypes() {
+    return mimetypeSubtypes;
+  }
+}

--- a/elasticsearch/autocomplete/src/test/java/nl/knaw/huc/resources/AutocompleteResourceTest.java
+++ b/elasticsearch/autocomplete/src/test/java/nl/knaw/huc/resources/AutocompleteResourceTest.java
@@ -124,8 +124,8 @@ public class AutocompleteResourceTest {
   public void testTypes_returnsMimetypesAndSubtypes() throws IOException {
     var response = application.client().target(getTestUrl("/types")).request().get();
     var types = response.readEntity(String.class);
-    assertThat(types).isEqualTo("{\"types\":[{\"mimetype\":\"application/xml\",\"subtypes\":[\"application/vnd.prima" +
-        ".page+xml\"]},{\"mimetype\":\"text/plain\",\"subtypes\":[]}]}");
+    assertThat(types).isEqualTo("{\"types\":[{\"mimetype\":\"application/xml\",\"subtypes\":[\"" +
+        "application/vnd.prima.page+xml\"]},{\"mimetype\":\"text/plain\",\"subtypes\":[]}]}");
   }
 
   private Response postTestContents(byte[] bytes, String mimetype) {

--- a/elasticsearch/autocomplete/src/test/java/nl/knaw/huc/resources/AutocompleteResourceTest.java
+++ b/elasticsearch/autocomplete/src/test/java/nl/knaw/huc/resources/AutocompleteResourceTest.java
@@ -108,6 +108,26 @@ public class AutocompleteResourceTest {
     assertThat(fields).contains("Unexpected mimetype: got [application/pdf] but should be one of [");
   }
 
+  @Test
+  public void testFields_returnsCompletionSuggesterInput_whenPageXml() throws IOException {
+    var fileContents = getResourceAsBytes("file.page.xml");
+    var response = postTestContents(fileContents, "application/vnd.prima.page+xml");
+    assertThat(response.getStatus()).isEqualTo(200);
+    var fields = response.readEntity(String.class);
+    var firstInput = JsonPath.parse(fields).read("$.suggest[0].input");
+    assertThat(firstInput).isEqualTo("evolutie");
+    var firstWeight = JsonPath.parse(fields).read("$.suggest[0].weight");
+    assertThat(firstWeight).isEqualTo(1);
+  }
+
+  @Test
+  public void testTypes_returnsMimetypesAndSubtypes() throws IOException {
+    var response = application.client().target(getTestUrl("/types")).request().get();
+    var types = response.readEntity(String.class);
+    assertThat(types).isEqualTo("{\"types\":[{\"mimetype\":\"application/xml\",\"subtypes\":[\"application/vnd.prima" +
+        ".page+xml\"]},{\"mimetype\":\"text/plain\",\"subtypes\":[]}]}");
+  }
+
   private Response postTestContents(byte[] bytes, String mimetype) {
     var contentDisposition = FormDataContentDisposition
         .name("file")

--- a/elasticsearch/autocomplete/src/test/resources/file.page.xml
+++ b/elasticsearch/autocomplete/src/test/resources/file.page.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<PcGts>
+  <schemaLocation/>
+  <Metadata/>
+  <Page imageWidth="0" imageHeight="0">
+    <ReadingOrder/>
+    <TextRegion orientation="0.0">
+      <Coords/>
+      <TextEquiv/>
+      <TextLine xheight="0">
+        <idString/>
+        <Coords points="2149,115 2231,115">
+          <Point/>
+        </Coords>
+        <Baseline points="2149,116 2150,116"/>
+        <TextEquiv>
+          <TextEquiv>
+            <Unicode>Twee glazen jenever veranderen een man meer dan honderdduizenden jaren evolutie.</Unicode>
+            <PlainText/>
+          </TextEquiv>
+          <PlainText/>
+        </TextEquiv>
+        <TextStyle/>
+      </TextLine>
+    </TextRegion>
+    <PrintSpace/>
+  </Page>
+  <pcGtsId/>
+</PcGts>

--- a/elasticsearch/autocomplete/src/test/resources/test-config.yml
+++ b/elasticsearch/autocomplete/src/test/resources/test-config.yml
@@ -6,3 +6,6 @@ logging:
 minKeywordLength: 5
 keywordDelimiters: " \t\n\r\f,.:;?![]'="
 mappingFile: ./autocomplete-mapping.json
+mimetypeSubtypes:
+  - mimetype: 'application/xml'
+    subtypes: [application/vnd.prima.page+xml]

--- a/elasticsearch/file/README.md
+++ b/elasticsearch/file/README.md
@@ -1,4 +1,4 @@
-# Full-text indexer
+# File indexer
 
 Run: see `../../README.md`
 

--- a/elasticsearch/full-text/Dockerfile
+++ b/elasticsearch/full-text/Dockerfile
@@ -7,7 +7,8 @@ FROM openjdk:11-jre-slim-stretch
 COPY --from=builder /build/target/full-text-1.0-SNAPSHOT.jar /indexer/full-text.jar
 
 WORKDIR /indexer
-COPY ./config.yml /indexer/
+RUN apt-get update && apt-get install -y gettext-base
+COPY ./config-template.yml /indexer/
 COPY ./full-text-mapping.json /indexer/
 COPY ./scripts/start.sh /indexer/
 

--- a/elasticsearch/full-text/README.md
+++ b/elasticsearch/full-text/README.md
@@ -22,3 +22,10 @@ Search in elasticsearch index by `<term>`:
 curl -X POST '<index-host>/_search' -H 'Content-Type:application/json' \
   -d '{"suggest":{"keyword-suggest":{"prefix":"<term>", "completion":{"field":"suggest","skip_duplicates":true,"size":5}}},"_source":false}'
 ```
+
+## Mimetypes and subtypes
+The full-text indexer knows about a number mimetypes.
+
+Besides those mimetypes the indexer has the concept of "mimetype subtypes", a configurable list of mimetypes that the full-text indexer will handle just like their "super" mimetype. E.g. pagexml or 'application/vnd.prima.page+xml' can be configured to be indexed just like ordinary xml or 'application/xml'.
+
+Check `<host>/full-text/types` for a list of mimetypes and their subtypes.

--- a/elasticsearch/full-text/config-template.yml
+++ b/elasticsearch/full-text/config-template.yml
@@ -1,0 +1,11 @@
+logging:
+  level: INFO
+  loggers:
+    nl.knaw.huc: DEBUG
+    org.hibernate: ERROR
+mappingFile: ./full-text-mapping.json
+mimetypeSubtypes:
+  - mimetype: 'application/xml'
+    subtypes: ${FULL_TEXT_XML_SUBTYPES}
+  - mimetype: 'text/plain'
+    subtypes: ${FULL_TEXT_TXT_SUBTYPES}

--- a/elasticsearch/full-text/config.yml
+++ b/elasticsearch/full-text/config.yml
@@ -1,6 +1,0 @@
-logging:
-  level: INFO
-  loggers:
-    nl.knaw.huc: DEBUG
-    org.hibernate: ERROR
-mappingFile: ./full-text-mapping.json

--- a/elasticsearch/full-text/scripts/start.sh
+++ b/elasticsearch/full-text/scripts/start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+envsubst < /indexer/config-template.yml > /indexer/config.yml
 
 java -jar full-text.jar server config.yml

--- a/elasticsearch/full-text/src/main/java/nl/knaw/huc/FullTextConfiguration.java
+++ b/elasticsearch/full-text/src/main/java/nl/knaw/huc/FullTextConfiguration.java
@@ -13,6 +13,10 @@ public class FullTextConfiguration extends Configuration {
   @NotNull
   private String mappingFile;
 
+  @Valid
+  @NotNull
+  private List<MimetypeSubtypesConfiguration> mimetypeSubtypes;
+
   @JsonProperty("mappingFile")
   public String getMappingFile() {
     return mappingFile;
@@ -22,4 +26,15 @@ public class FullTextConfiguration extends Configuration {
   public void setMappingFile(String mappingFile) {
     this.mappingFile = mappingFile;
   }
+
+  @JsonProperty("mimetypeSubtypes")
+  public List<MimetypeSubtypesConfiguration> getMimetypeSubtypes() {
+    return mimetypeSubtypes;
+  }
+
+  @JsonProperty("mimetypeSubtypes")
+  public void setMimetypeSubtypes(List<MimetypeSubtypesConfiguration> mimetypeSubtypes) {
+    this.mimetypeSubtypes = mimetypeSubtypes;
+  }
+
 }

--- a/elasticsearch/full-text/src/main/java/nl/knaw/huc/FullTextIndexer.java
+++ b/elasticsearch/full-text/src/main/java/nl/knaw/huc/FullTextIndexer.java
@@ -9,6 +9,7 @@ import nl.knaw.huc.health.MappingFileHealthCheck;
 import nl.knaw.huc.resources.FullTextResource;
 import nl.knaw.huc.service.FieldsService;
 import nl.knaw.huc.service.MappingService;
+import nl.knaw.huc.service.SubtypeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,9 @@ public class FullTextIndexer extends Application<FullTextConfiguration> {
   public void run(FullTextConfiguration config, Environment environment) {
     var contentsService = new FieldsService(config);
     var mappingService = new MappingService(config);
-    var contentsResource = new FullTextResource(contentsService, mappingService);
+    var subtypeService = new SubtypeService(config.getMimetypeSubtypes());
+
+    var contentsResource = new FullTextResource(contentsService, mappingService, subtypeService);
     environment.jersey().register(contentsResource);
     environment.healthChecks().register("mapping file", new MappingFileHealthCheck(config));
     environment.jersey().register(new IllegalMimetypeExceptionMapper());

--- a/elasticsearch/full-text/src/main/java/nl/knaw/huc/MimetypeSubtypesConfiguration.java
+++ b/elasticsearch/full-text/src/main/java/nl/knaw/huc/MimetypeSubtypesConfiguration.java
@@ -1,0 +1,38 @@
+package nl.knaw.huc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+public class MimetypeSubtypesConfiguration {
+
+  @Valid
+  @NotNull
+  private String mimetype;
+
+  @Valid
+  @NotNull
+  private List<String> subtypes;
+
+  @JsonProperty("subtypes")
+  public List<String> getSubtypes() {
+    return subtypes;
+  }
+
+  @JsonProperty("subtypes")
+  public void setSubtypes(List<String> subtypes) {
+    this.subtypes = subtypes;
+  }
+
+  @JsonProperty("mimetype")
+  public String getMimetype() {
+    return mimetype;
+  }
+
+  @JsonProperty("mimetype")
+  public void setMimetype(String mimetype) {
+    this.mimetype = mimetype;
+  }
+}

--- a/elasticsearch/full-text/src/main/java/nl/knaw/huc/api/MimetypeSubtypesResult.java
+++ b/elasticsearch/full-text/src/main/java/nl/knaw/huc/api/MimetypeSubtypesResult.java
@@ -1,0 +1,42 @@
+package nl.knaw.huc.api;
+
+import nl.knaw.huc.MimetypeSubtypesConfiguration;
+import nl.knaw.huc.core.SupportedType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MimetypeSubtypesResult {
+
+  public List<MimetypeSubtypeResult> types = new ArrayList<>();
+
+  /**
+   * Merge SupportedTypes and mimetypeSubtypes into a single List< MimetypeSubtype >
+   */
+  public MimetypeSubtypesResult(List<MimetypeSubtypesConfiguration> mimetypeSubtypes) {
+    for (var mimetype : SupportedType.values()) {
+      var subtypes = mimetypeSubtypes
+          .stream()
+          .filter(st -> st.getMimetype().equals(mimetype.getMimetype()))
+          .map(MimetypeSubtypesConfiguration::getSubtypes)
+          .findFirst();
+
+      var typeResult = new MimetypeSubtypeResult(
+          mimetype.getMimetype(),
+          subtypes.orElse(new ArrayList<>())
+      );
+      types.add(typeResult);
+    }
+  }
+
+  public static class MimetypeSubtypeResult {
+    public String mimetype;
+    public List<String> subtypes;
+
+    public MimetypeSubtypeResult(String mimetype, List<String> subtypes) {
+
+      this.mimetype = mimetype;
+      this.subtypes = subtypes;
+    }
+  }
+}

--- a/elasticsearch/full-text/src/main/java/nl/knaw/huc/core/SupportedType.java
+++ b/elasticsearch/full-text/src/main/java/nl/knaw/huc/core/SupportedType.java
@@ -19,6 +19,10 @@ public enum SupportedType {
     this.mimetype = mimetype;
   }
 
+  public static boolean exists(String mimetype) {
+    return stream(values()).anyMatch(st -> st.mimetype.equals(mimetype));
+  }
+
   public String getMimetype() {
     return mimetype;
   }
@@ -29,9 +33,17 @@ public enum SupportedType {
         return supportedType;
       }
     }
-    throw new IllegalMimetypeException(format(
-        "Unexpected mimetype: got [%s] but should be one of [%s]",
-        mimetype, stream(values()).map(v -> "" + v.getMimetype()).collect(joining(", ")))
-    );
+    throw unexpectedMimetype(mimetype);
+  }
+
+  public static IllegalMimetypeException unexpectedMimetype(String mimetype) {
+    return new IllegalMimetypeException(format(
+        "Unexpected mimetype: got [%s] but should be one of [%s] or their subtypes",
+        mimetype, supported()
+    ));
+  }
+
+  private static String supported() {
+    return stream(values()).map(v -> "" + v.getMimetype()).collect(joining(", "));
   }
 }

--- a/elasticsearch/full-text/src/main/java/nl/knaw/huc/service/FieldsService.java
+++ b/elasticsearch/full-text/src/main/java/nl/knaw/huc/service/FieldsService.java
@@ -51,11 +51,17 @@ public class FieldsService {
   private Fields fromTxt(@NotNull InputStream inputStream) {
     String text;
     try {
-      text = IOUtils.toString(inputStream, UTF_8);
+      text = this.cleanUp(IOUtils.toString(inputStream, UTF_8));
     } catch (IOException e) {
       throw new IllegalArgumentException("Input stream could not be converted to string");
     }
     return new Fields(text);
+  }
+
+  private String cleanUp(String contents) {
+    return contents
+        .trim()
+        .replaceAll(" +", " ");
   }
 
   private Fields parseWithTika(InputStream inputStream, AbstractParser parser) {
@@ -71,7 +77,7 @@ public class FieldsService {
     } catch (IOException | SAXException | TikaException ex) {
       throw new BadRequestException("Could not parse file using tika", ex);
     }
-    return new Fields(handler.toString());
+    return new Fields(this.cleanUp(handler.toString()));
   }
 
   private byte[] getBytes(InputStream xml) {

--- a/elasticsearch/full-text/src/main/java/nl/knaw/huc/service/FieldsService.java
+++ b/elasticsearch/full-text/src/main/java/nl/knaw/huc/service/FieldsService.java
@@ -51,17 +51,11 @@ public class FieldsService {
   private Fields fromTxt(@NotNull InputStream inputStream) {
     String text;
     try {
-      text = this.cleanUp(IOUtils.toString(inputStream, UTF_8));
+      text = cleanUp(IOUtils.toString(inputStream, UTF_8));
     } catch (IOException e) {
       throw new IllegalArgumentException("Input stream could not be converted to string");
     }
     return new Fields(text);
-  }
-
-  private String cleanUp(String contents) {
-    return contents
-        .trim()
-        .replaceAll(" +", " ");
   }
 
   private Fields parseWithTika(InputStream inputStream, AbstractParser parser) {
@@ -77,7 +71,7 @@ public class FieldsService {
     } catch (IOException | SAXException | TikaException ex) {
       throw new BadRequestException("Could not parse file using tika", ex);
     }
-    return new Fields(this.cleanUp(handler.toString()));
+    return new Fields(cleanUp(handler.toString()));
   }
 
   private byte[] getBytes(InputStream xml) {
@@ -90,4 +84,9 @@ public class FieldsService {
     return baos.toByteArray();
   }
 
+  private String cleanUp(String contents) {
+    return contents
+        .trim()
+        .replaceAll(" +", " ");
+  }
 }

--- a/elasticsearch/full-text/src/main/java/nl/knaw/huc/service/SubtypeService.java
+++ b/elasticsearch/full-text/src/main/java/nl/knaw/huc/service/SubtypeService.java
@@ -1,0 +1,33 @@
+package nl.knaw.huc.service;
+
+import nl.knaw.huc.MimetypeSubtypesConfiguration;
+import nl.knaw.huc.core.SupportedType;
+
+import java.util.List;
+
+public class SubtypeService {
+
+  private final List<MimetypeSubtypesConfiguration> mimetypeSubtypes;
+
+  public SubtypeService(List<MimetypeSubtypesConfiguration> mimetypeSubtypes) {
+    this.mimetypeSubtypes = mimetypeSubtypes;
+  }
+
+  public SupportedType determine(String mimetype) {
+    if (SupportedType.exists(mimetype)) {
+      return SupportedType.fromString(mimetype);
+    }
+
+    for (var mimetypeSubtype : mimetypeSubtypes) {
+      if (mimetypeSubtype.getSubtypes().contains(mimetype)) {
+        return SupportedType.fromString(mimetypeSubtype.getMimetype());
+      }
+    }
+
+    throw SupportedType.unexpectedMimetype(mimetype);
+  }
+
+  public List<MimetypeSubtypesConfiguration> getMimetypeSubtypes() {
+    return mimetypeSubtypes;
+  }
+}

--- a/elasticsearch/full-text/src/test/resources/file.page.xml
+++ b/elasticsearch/full-text/src/test/resources/file.page.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<PcGts>
+  <schemaLocation/>
+  <Metadata/>
+  <Page imageWidth="0" imageHeight="0">
+    <ReadingOrder/>
+    <TextRegion orientation="0.0">
+      <Coords/>
+      <TextEquiv/>
+      <TextLine xheight="0">
+        <idString/>
+        <Coords points="2149,115 2231,115">
+          <Point/>
+        </Coords>
+        <Baseline points="2149,116 2150,116"/>
+        <TextEquiv>
+          <TextEquiv>
+            <Unicode>Twee glazen jenever veranderen een man meer dan honderdduizenden jaren evolutie.</Unicode>
+            <PlainText/>
+          </TextEquiv>
+          <PlainText/>
+        </TextEquiv>
+        <TextStyle/>
+      </TextLine>
+    </TextRegion>
+    <PrintSpace/>
+  </Page>
+  <pcGtsId/>
+</PcGts>

--- a/elasticsearch/full-text/src/test/resources/test-config.yml
+++ b/elasticsearch/full-text/src/test/resources/test-config.yml
@@ -1,2 +1,4 @@
 mappingFile: ./full-text-mapping.json
-
+mimetypeSubtypes:
+  - mimetype: 'application/xml'
+    subtypes: [application/vnd.prima.page+xml]

--- a/elasticsearch/spacy-ner/README.md
+++ b/elasticsearch/spacy-ner/README.md
@@ -16,13 +16,12 @@ Text repository indexer that recognizes named entities using spacy, flask and do
     networks:
       - textrepo_network
     volumes:
-      - ./scripts/wait-for-it.sh:/tagger/wait-for-it.sh
       - ./elasticsearch/spacy-ner/model:/indexer/model
+      - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "./wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "/indexer/wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
-
 ```
 
 - Add to `TR_INDEXERS` in `./docker-compose.env`:

--- a/examples/development/docker-compose-dev.yml
+++ b/examples/development/docker-compose-dev.yml
@@ -67,6 +67,9 @@ services:
   autocomplete-indexer:
     container_name: tr_autocomplete
     image: knawhuc/textrepo-autocomplete-indexer:${DOCKER_TAG}
+    environment:
+      AUTOCOMPLETE_XML_SUBTYPES: ${AUTOCOMPLETE_XML_SUBTYPES}
+      AUTOCOMPLETE_TXT_SUBTYPES: ${AUTOCOMPLETE_TXT_SUBTYPES}
     build: ./elasticsearch/autocomplete
     ports:
       - 8080
@@ -82,6 +85,9 @@ services:
   full-text-indexer:
     container_name: tr_full-text
     image: knawhuc/textrepo-full-text-indexer:${DOCKER_TAG}
+    environment:
+      FULL_TEXT_XML_SUBTYPES: ${FULL_TEXT_XML_SUBTYPES}
+      FULL_TEXT_TXT_SUBTYPES: ${FULL_TEXT_TXT_SUBTYPES}
     build: ./elasticsearch/full-text
     ports:
       - 8080

--- a/examples/development/docker-compose.env
+++ b/examples/development/docker-compose.env
@@ -110,3 +110,9 @@ export CONCORDION_APP_HOST_ADMIN=textrepo-app:8081
 export CONCORDION_ROOT_REDIRECT=/concordion/nl/knaw/huc/textrepo/TextRepo.html
 
 export INTERNAL_TR_HOST=http://textrepo-app:8080
+
+export AUTOCOMPLETE_XML_SUBTYPES='[application/vnd.prima.page+xml, text/vnd.hocr+html]'
+export AUTOCOMPLETE_TXT_SUBTYPES='[]'
+
+export FULL_TEXT_XML_SUBTYPES='[application/vnd.prima.page+xml, text/vnd.hocr+html]'
+export FULL_TEXT_TXT_SUBTYPES='[]'

--- a/examples/production/docker-compose-integration.yml
+++ b/examples/production/docker-compose-integration.yml
@@ -65,6 +65,9 @@ services:
   autocomplete-indexer:
     container_name: tr_autocomplete
     image: knawhuc/textrepo-autocomplete-indexer:${DOCKER_TAG}
+    environment:
+      AUTOCOMPLETE_XML_SUBTYPES: ${AUTOCOMPLETE_XML_SUBTYPES}
+      AUTOCOMPLETE_TXT_SUBTYPES: ${AUTOCOMPLETE_TXT_SUBTYPES}
     ports:
       - 8080
     networks:
@@ -79,6 +82,9 @@ services:
   full-text-indexer:
     container_name: tr_full-text
     image: knawhuc/textrepo-full-text-indexer:${DOCKER_TAG}
+    environment:
+      FULL_TEXT_XML_SUBTYPES: ${FULL_TEXT_XML_SUBTYPES}
+      FULL_TEXT_TXT_SUBTYPES: ${FULL_TEXT_TXT_SUBTYPES}
     ports:
       - 8080
     networks:

--- a/examples/production/docker-compose-prod.yml
+++ b/examples/production/docker-compose-prod.yml
@@ -65,6 +65,9 @@ services:
   autocomplete-indexer:
     container_name: tr_autocomplete
     image: knawhuc/textrepo-autocomplete-indexer:${DOCKER_TAG}
+    environment:
+      AUTOCOMPLETE_XML_SUBTYPES: ${AUTOCOMPLETE_XML_SUBTYPES}
+      AUTOCOMPLETE_TXT_SUBTYPES: ${AUTOCOMPLETE_TXT_SUBTYPES}
     ports:
       - 8080
     networks:
@@ -79,6 +82,9 @@ services:
   full-text-indexer:
     container_name: tr_full-text
     image: knawhuc/textrepo-full-text-indexer:${DOCKER_TAG}
+    environment:
+      FULL_TEXT_XML_SUBTYPES: ${FULL_TEXT_XML_SUBTYPES}
+      FULL_TEXT_TXT_SUBTYPES: ${FULL_TEXT_TXT_SUBTYPES}
     ports:
       - 8080
     networks:

--- a/examples/production/docker-compose.env
+++ b/examples/production/docker-compose.env
@@ -104,3 +104,9 @@ export CONCORDION_APP_HOST_ADMIN=textrepo-app:8081
 export CONCORDION_ROOT_REDIRECT=/concordion/nl/knaw/huc/textrepo/TextRepo.html
 
 export INTERNAL_TR_HOST=http://textrepo-app:8080
+
+export AUTOCOMPLETE_XML_SUBTYPES='[application/vnd.prima.page+xml, text/vnd.hocr+html]'
+export AUTOCOMPLETE_TXT_SUBTYPES='[]'
+
+export FULL_TEXT_XML_SUBTYPES='[application/vnd.prima.page+xml, text/vnd.hocr+html]'
+export FULL_TEXT_TXT_SUBTYPES='[]'


### PR DESCRIPTION
The full-text and autocomplete indexer know about a number mimetypes. However, sometimes mimetypes can overlap. E.g. pagexml or 'application/vnd.prima.page+xml' is a specific kind of xml or 'application/xml'. To allow the indexers to index pagexml as normal xml, the concept of "subtype" is introduced, which defines which mimetype subtypes can be indexed according to their "super mimetype".
