### PR TITLE
Improve/fix swagger.json to improve the swagger-codegen generated code

### DIFF
--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/dashboard/DashboardResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/dashboard/DashboardResource.java
@@ -60,7 +60,7 @@ public class DashboardResource {
   @Path("/orphans")
   @Produces(APPLICATION_JSON)
   @ApiOperation("Find orphans: documents with neither metadata nor any associated files")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
+  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultPage.class, message = "OK")})
   public ResultPage<ResultDocument> findOrphans(@BeanParam FormPageParams pageParams) {
     log.debug("Find orphans, pageParams={}", pageParams);
     var orphans = dashboardService.findOrphans(paginator.fromForm(pageParams));

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/ContentsResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/ContentsResource.java
@@ -43,7 +43,7 @@ public class ContentsResource {
   @Produces({APPLICATION_OCTET_STREAM, APPLICATION_JSON})
   @ApiOperation(value = "Retrieve contents")
   @ApiResponses(value = {@ApiResponse(code = 200, response = byte[].class, message = "OK")})
-  public Response get(
+  public Response getContents(
       @HeaderParam(ACCEPT_ENCODING) String acceptEncoding,
       @PathParam("sha") @NotBlank String sha
   ) {

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentFilesResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentFilesResource.java
@@ -5,7 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import nl.knaw.huc.api.FormPageParams;
-import nl.knaw.huc.api.ResultDocument;
+import nl.knaw.huc.api.ResultPage;
 import nl.knaw.huc.api.ResultTextRepoFile;
 import nl.knaw.huc.core.TextRepoFile;
 import nl.knaw.huc.helpers.Paginator;
@@ -45,8 +45,8 @@ public class DocumentFilesResource {
   @GET
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve document files")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-  public Response get(
+  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultPage.class, message = "OK")})
+  public Response getDocumentFiles(
       @PathParam("docId") @Valid UUID docId,
       @BeanParam FormPageParams pageParams
   ) {

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentMetadataResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentMetadataResource.java
@@ -50,14 +50,14 @@ public class DocumentMetadataResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = POST_ERROR_MSG)
   @ApiResponses(value = {@ApiResponse(code = 405, message = POST_ERROR_MSG)})
-  public Response post() {
+  public Response postDocumentMetadataIsNotAllowed() {
     throw new MethodNotAllowedException(POST_ERROR_MSG);
   }
 
   @GET
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve document metadata")
-  public Map<String, String> get(
+  public Map<String, String> getDocumentMetadata(
       @PathParam("docId") @NotNull @Valid UUID docId
   ) {
     log.debug("Get document metadata: docId={}", docId);
@@ -73,7 +73,7 @@ public class DocumentMetadataResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create or update document metadata entry")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-  public Response update(
+  public Response putDocumentMetadataEntry(
       @PathParam("docId") @NotNull @Valid UUID docId,
       @PathParam("key") @NotBlank String key,
       @NotNull String value
@@ -92,7 +92,7 @@ public class DocumentMetadataResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Delete document metadata entry")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-  public Response delete(
+  public Response deleteDocumentMetadataEntry(
       @PathParam("docId") @NotNull @Valid UUID docId,
       @PathParam("key") @NotBlank String key
   ) {

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentsResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentsResource.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiResponses;
 import nl.knaw.huc.api.FormDocument;
 import nl.knaw.huc.api.FormPageParams;
 import nl.knaw.huc.api.ResultDocument;
+import nl.knaw.huc.api.ResultPage;
 import nl.knaw.huc.core.Document;
 import nl.knaw.huc.helpers.Paginator;
 import nl.knaw.huc.service.document.DocumentService;
@@ -14,17 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.validation.Valid;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -54,7 +45,7 @@ public class DocumentsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create document")
   @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-  public Response post(
+  public Response createDocument(
       @Valid FormDocument form
   ) {
     log.debug("Create document: {}", form);
@@ -66,8 +57,8 @@ public class DocumentsResource {
   @GET
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve documents, newest first")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-  public Response get(
+  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultPage.class, message = "OK")})
+  public Response getDocuments(
       @QueryParam("externalId") String externalId,
       @QueryParam("createdAfter") LocalDateTime createdAfter,
       @BeanParam FormPageParams pageParams
@@ -85,7 +76,7 @@ public class DocumentsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve document")
   @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-  public Response get(
+  public Response getDocument(
       @PathParam("id") @Valid UUID id
   ) {
     log.debug("Get document: id={}", id);
@@ -104,7 +95,7 @@ public class DocumentsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create or update document")
   @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-  public Response put(
+  public Response updateDocument(
       @PathParam("id") @Valid UUID id,
       @Valid FormDocument form
   ) {
@@ -118,7 +109,7 @@ public class DocumentsResource {
   @Path("/{id}")
   @ApiOperation(value = "Delete document")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-  public Response delete(
+  public Response deleteDocument(
       @PathParam("id") @Valid UUID id
   ) {
     log.debug("Delete document: id={}", id);

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentsResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentsResource.java
@@ -15,7 +15,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.validation.Valid;
-import javax.ws.rs.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -28,94 +38,94 @@ import static nl.knaw.huc.helpers.Paginator.toResult;
 @Path("/rest/documents")
 public class DocumentsResource {
 
-  private static final Logger log = LoggerFactory.getLogger(DocumentsResource.class);
-  private final DocumentService documentService;
-  private final Paginator paginator;
+    private static final Logger log = LoggerFactory.getLogger(DocumentsResource.class);
+    private final DocumentService documentService;
+    private final Paginator paginator;
 
-  public DocumentsResource(
-      DocumentService documentService,
-      Paginator paginator
-  ) {
-    this.documentService = requireNonNull(documentService);
-    this.paginator = requireNonNull(paginator);
-  }
+    public DocumentsResource(
+            DocumentService documentService,
+            Paginator paginator
+    ) {
+        this.documentService = requireNonNull(documentService);
+        this.paginator = requireNonNull(paginator);
+    }
 
-  @POST
-  @Consumes(APPLICATION_JSON)
-  @Produces(APPLICATION_JSON)
-  @ApiOperation(value = "Create document")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-  public Response createDocument(
-      @Valid FormDocument form
-  ) {
-    log.debug("Create document: {}", form);
-    var doc = documentService.create(new Document(null, form.getExternalId()));
-    log.debug("Created document: {}", doc);
-    return Response.ok(new ResultDocument(doc)).build();
-  }
+    @POST
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = "Create document")
+    @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
+    public Response createDocument(
+            @Valid FormDocument form
+    ) {
+        log.debug("Create document: {}", form);
+        var doc = documentService.create(new Document(null, form.getExternalId()));
+        log.debug("Created document: {}", doc);
+        return Response.ok(new ResultDocument(doc)).build();
+    }
 
-  @GET
-  @Produces(APPLICATION_JSON)
-  @ApiOperation(value = "Retrieve documents, newest first")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultPage.class, message = "OK")})
-  public Response getDocuments(
-      @QueryParam("externalId") String externalId,
-      @QueryParam("createdAfter") LocalDateTime createdAfter,
-      @BeanParam FormPageParams pageParams
-  ) {
-    log.debug("Get documents: externalId={}; createdAfter={}; pageParams={}", externalId, createdAfter, pageParams);
-    var docs = documentService.getAll(externalId, createdAfter, paginator.fromForm(pageParams));
-    log.debug("Got documents: {}", docs);
-    return Response
-        .ok(toResult(docs, ResultDocument::new))
-        .build();
-  }
+    @GET
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = "Retrieve documents, newest first")
+    @ApiResponses(value = {@ApiResponse(code = 200, response = ResultPage.class, message = "OK")})
+    public Response getDocuments(
+            @QueryParam("externalId") String externalId,
+            @QueryParam("createdAfter") LocalDateTime createdAfter,
+            @BeanParam FormPageParams pageParams
+    ) {
+        log.debug("Get documents: externalId={}; createdAfter={}; pageParams={}", externalId, createdAfter, pageParams);
+        var docs = documentService.getAll(externalId, createdAfter, paginator.fromForm(pageParams));
+        log.debug("Got documents: {}", docs);
+        return Response
+                .ok(toResult(docs, ResultDocument::new))
+                .build();
+    }
 
-  @GET
-  @Path("/{id}")
-  @Produces(APPLICATION_JSON)
-  @ApiOperation(value = "Retrieve document")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-  public Response getDocument(
-      @PathParam("id") @Valid UUID id
-  ) {
-    log.debug("Get document: id={}", id);
-    final var doc = documentService
-        .get(id)
-        .orElseThrow(NotFoundException::new);
-    log.debug("Got document: {}", doc);
-    return Response
-        .ok(new ResultDocument(doc))
-        .build();
-  }
+    @GET
+    @Path("/{id}")
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = "Retrieve document")
+    @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
+    public Response getDocument(
+            @PathParam("id") @Valid UUID id
+    ) {
+        log.debug("Get document: id={}", id);
+        final var doc = documentService
+                .get(id)
+                .orElseThrow(NotFoundException::new);
+        log.debug("Got document: {}", doc);
+        return Response
+                .ok(new ResultDocument(doc))
+                .build();
+    }
 
-  @PUT
-  @Path("/{id}")
-  @Consumes(APPLICATION_JSON)
-  @Produces(APPLICATION_JSON)
-  @ApiOperation(value = "Create or update document")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-  public Response updateDocument(
-      @PathParam("id") @Valid UUID id,
-      @Valid FormDocument form
-  ) {
-    log.debug("Update document: id={}; form={}", id, form);
-    var doc = documentService.update(new Document(id, form.getExternalId()));
-    log.debug("Updated document: {}", doc);
-    return Response.ok(new ResultDocument(doc)).build();
-  }
+    @PUT
+    @Path("/{id}")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = "Create or update document")
+    @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
+    public Response putDocument(
+            @PathParam("id") @Valid UUID id,
+            @Valid FormDocument form
+    ) {
+        log.debug("Update document: id={}; form={}", id, form);
+        var doc = documentService.update(new Document(id, form.getExternalId()));
+        log.debug("Updated document: {}", doc);
+        return Response.ok(new ResultDocument(doc)).build();
+    }
 
-  @DELETE
-  @Path("/{id}")
-  @ApiOperation(value = "Delete document")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-  public Response deleteDocument(
-      @PathParam("id") @Valid UUID id
-  ) {
-    log.debug("Delete document: id={}", id);
-    documentService.delete(id);
-    log.debug("Deleted document");
-    return Response.ok().build();
-  }
+    @DELETE
+    @Path("/{id}")
+    @ApiOperation(value = "Delete document")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
+    public Response deleteDocument(
+            @PathParam("id") @Valid UUID id
+    ) {
+        log.debug("Delete document: id={}", id);
+        documentService.delete(id);
+        log.debug("Deleted document");
+        return Response.ok().build();
+    }
 
 }

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentsResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentsResource.java
@@ -38,94 +38,94 @@ import static nl.knaw.huc.helpers.Paginator.toResult;
 @Path("/rest/documents")
 public class DocumentsResource {
 
-    private static final Logger log = LoggerFactory.getLogger(DocumentsResource.class);
-    private final DocumentService documentService;
-    private final Paginator paginator;
+  private static final Logger log = LoggerFactory.getLogger(DocumentsResource.class);
+  private final DocumentService documentService;
+  private final Paginator paginator;
 
-    public DocumentsResource(
-            DocumentService documentService,
-            Paginator paginator
-    ) {
-        this.documentService = requireNonNull(documentService);
-        this.paginator = requireNonNull(paginator);
-    }
+  public DocumentsResource(
+      DocumentService documentService,
+      Paginator paginator
+  ) {
+    this.documentService = requireNonNull(documentService);
+    this.paginator = requireNonNull(paginator);
+  }
 
-    @POST
-    @Consumes(APPLICATION_JSON)
-    @Produces(APPLICATION_JSON)
-    @ApiOperation(value = "Create document")
-    @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-    public Response createDocument(
-            @Valid FormDocument form
-    ) {
-        log.debug("Create document: {}", form);
-        var doc = documentService.create(new Document(null, form.getExternalId()));
-        log.debug("Created document: {}", doc);
-        return Response.ok(new ResultDocument(doc)).build();
-    }
+  @POST
+  @Consumes(APPLICATION_JSON)
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(value = "Create document")
+  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
+  public Response createDocument(
+      @Valid FormDocument form
+  ) {
+    log.debug("Create document: {}", form);
+    var doc = documentService.create(new Document(null, form.getExternalId()));
+    log.debug("Created document: {}", doc);
+    return Response.ok(new ResultDocument(doc)).build();
+  }
 
-    @GET
-    @Produces(APPLICATION_JSON)
-    @ApiOperation(value = "Retrieve documents, newest first")
-    @ApiResponses(value = {@ApiResponse(code = 200, response = ResultPage.class, message = "OK")})
-    public Response getDocuments(
-            @QueryParam("externalId") String externalId,
-            @QueryParam("createdAfter") LocalDateTime createdAfter,
-            @BeanParam FormPageParams pageParams
-    ) {
-        log.debug("Get documents: externalId={}; createdAfter={}; pageParams={}", externalId, createdAfter, pageParams);
-        var docs = documentService.getAll(externalId, createdAfter, paginator.fromForm(pageParams));
-        log.debug("Got documents: {}", docs);
-        return Response
-                .ok(toResult(docs, ResultDocument::new))
-                .build();
-    }
+  @GET
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(value = "Retrieve documents, newest first")
+  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultPage.class, message = "OK")})
+  public Response getDocuments(
+      @QueryParam("externalId") String externalId,
+      @QueryParam("createdAfter") LocalDateTime createdAfter,
+      @BeanParam FormPageParams pageParams
+  ) {
+    log.debug("Get documents: externalId={}; createdAfter={}; pageParams={}", externalId, createdAfter, pageParams);
+    var docs = documentService.getAll(externalId, createdAfter, paginator.fromForm(pageParams));
+    log.debug("Got documents: {}", docs);
+    return Response
+        .ok(toResult(docs, ResultDocument::new))
+        .build();
+  }
 
-    @GET
-    @Path("/{id}")
-    @Produces(APPLICATION_JSON)
-    @ApiOperation(value = "Retrieve document")
-    @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-    public Response getDocument(
-            @PathParam("id") @Valid UUID id
-    ) {
-        log.debug("Get document: id={}", id);
-        final var doc = documentService
-                .get(id)
-                .orElseThrow(NotFoundException::new);
-        log.debug("Got document: {}", doc);
-        return Response
-                .ok(new ResultDocument(doc))
-                .build();
-    }
+  @GET
+  @Path("/{id}")
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(value = "Retrieve document")
+  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
+  public Response getDocument(
+      @PathParam("id") @Valid UUID id
+  ) {
+    log.debug("Get document: id={}", id);
+    final var doc = documentService
+        .get(id)
+        .orElseThrow(NotFoundException::new);
+    log.debug("Got document: {}", doc);
+    return Response
+        .ok(new ResultDocument(doc))
+        .build();
+  }
 
-    @PUT
-    @Path("/{id}")
-    @Consumes(APPLICATION_JSON)
-    @Produces(APPLICATION_JSON)
-    @ApiOperation(value = "Create or update document")
-    @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
-    public Response putDocument(
-            @PathParam("id") @Valid UUID id,
-            @Valid FormDocument form
-    ) {
-        log.debug("Update document: id={}; form={}", id, form);
-        var doc = documentService.update(new Document(id, form.getExternalId()));
-        log.debug("Updated document: {}", doc);
-        return Response.ok(new ResultDocument(doc)).build();
-    }
+  @PUT
+  @Path("/{id}")
+  @Consumes(APPLICATION_JSON)
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(value = "Create or update document")
+  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
+  public Response putDocument(
+      @PathParam("id") @Valid UUID id,
+      @Valid FormDocument form
+  ) {
+    log.debug("Update document: id={}; form={}", id, form);
+    var doc = documentService.update(new Document(id, form.getExternalId()));
+    log.debug("Updated document: {}", doc);
+    return Response.ok(new ResultDocument(doc)).build();
+  }
 
-    @DELETE
-    @Path("/{id}")
-    @ApiOperation(value = "Delete document")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-    public Response deleteDocument(
-            @PathParam("id") @Valid UUID id
-    ) {
-        log.debug("Delete document: id={}", id);
-        documentService.delete(id);
-        log.debug("Deleted document");
-        return Response.ok().build();
-    }
+  @DELETE
+  @Path("/{id}")
+  @ApiOperation(value = "Delete document")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
+  public Response deleteDocument(
+      @PathParam("id") @Valid UUID id
+  ) {
+    log.debug("Delete document: id={}", id);
+    documentService.delete(id);
+    log.debug("Deleted document");
+    return Response.ok().build();
+  }
 
 }

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/FileMetadataResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/FileMetadataResource.java
@@ -47,7 +47,7 @@ public class FileMetadataResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = POST_ERROR_MSG)
   @ApiResponses(value = {@ApiResponse(code = 405, message = POST_ERROR_MSG)})
-  public Response post() {
+  public Response postFileMetadata() {
     throw new MethodNotAllowedException(POST_ERROR_MSG);
   }
 
@@ -56,7 +56,7 @@ public class FileMetadataResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve file metadata")
   @ApiResponses(value = {@ApiResponse(code = 200, responseContainer = "Map", response = String.class, message = "OK")})
-  public Response get(
+  public Response getFileMetadata(
       @PathParam("fileId") @NotNull @Valid UUID fileId
   ) {
     log.debug("Get file metadata: fileId={}", fileId);
@@ -72,7 +72,7 @@ public class FileMetadataResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create or update file metadata entry")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-  public Response put(
+  public Response putFileMetadataEntry(
       @PathParam("fileId") @Valid UUID fileId,
       @PathParam("key") @NotNull String key,
       @NotNull String value
@@ -89,9 +89,9 @@ public class FileMetadataResource {
   @Timed
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
-  @ApiOperation(value = "Delete document metadata entry")
+  @ApiOperation(value = "Delete file metadata entry")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-  public Response delete(
+  public Response deleteFileMetadataEntry(
       @PathParam("fileId") @NotNull @Valid UUID fileId,
       @PathParam("key") @NotBlank String key
   ) {

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/FileVersionsResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/FileVersionsResource.java
@@ -49,7 +49,7 @@ public class FileVersionsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation("Retrieve file versions, newest first")
   @ApiResponses({@ApiResponse(code = 200, response = ResultVersion.class, message = "OK")})
-  public Response getVersions(
+  public Response getFileVersions(
       @PathParam("fileId") @Valid UUID fileId,
       @BeanParam FormPageParams pageParams,
       @QueryParam("createdAfter") LocalDateTime createdAfter

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/FilesResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/FilesResource.java
@@ -45,7 +45,7 @@ public class FilesResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create file")
   @ApiResponses(value = {@ApiResponse(code = 200, response = ResultTextRepoFile.class, message = "OK")})
-  public Response post(
+  public Response createFile(
       @Valid FormTextRepoFile form
   ) {
     log.debug("Create file: form={}", form);
@@ -60,7 +60,7 @@ public class FilesResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve file")
   @ApiResponses(value = {@ApiResponse(code = 200, response = ResultTextRepoFile.class, message = "OK")})
-  public Response get(
+  public Response getFile(
       @PathParam("id") @NotNull @Valid UUID id
   ) {
     log.debug("Get file: id={}", id);
@@ -76,7 +76,7 @@ public class FilesResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create or update file")
   @ApiResponses(value = {@ApiResponse(code = 200, response = ResultTextRepoFile.class, message = "OK")})
-  public Response put(
+  public Response putFile(
       @PathParam("id") @Valid UUID id,
       @Valid FormTextRepoFile form
   ) {
@@ -90,7 +90,7 @@ public class FilesResource {
   @Path("/{id}")
   @ApiOperation(value = "Delete file")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-  public Response delete(
+  public Response deleteFile(
       @PathParam("id") @Valid UUID id
   ) {
     log.debug("Delete file: id={}", id);

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/TypesResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/TypesResource.java
@@ -41,7 +41,7 @@ public class TypesResource {
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create type")
-  public Response post(
+  public Response createType(
       @Valid @NotNull FormType form
   ) {
     var type = new Type(form.getName(), form.getMimetype());
@@ -54,7 +54,7 @@ public class TypesResource {
   @GET
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve types")
-  public Response getAll() {
+  public Response getTypes() {
     log.debug("Retrieve all types");
     var all = typeService
         .list()
@@ -69,7 +69,7 @@ public class TypesResource {
   @Path("/{id}")
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve types")
-  public Response get(
+  public Response getType(
       @NotNull @PathParam("id") Short id
   ) {
     log.debug("Retrieve type: id={}", id);
@@ -83,7 +83,7 @@ public class TypesResource {
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create or update type")
-  public Response put(
+  public Response putType(
       @NotNull @PathParam("id") Short id,
       @NotNull @Valid FormType form
   ) {
@@ -98,7 +98,7 @@ public class TypesResource {
   @DELETE
   @Path("/{id}")
   @ApiOperation(value = "Delete type")
-  public Response delete(
+  public Response deleteType(
       @NotNull @PathParam("id") Short id
   ) {
     log.debug("Delete type: id={}", id);

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/VersionContentsResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/VersionContentsResource.java
@@ -50,7 +50,7 @@ public class VersionContentsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = POST_ERROR_MSG)
   @ApiResponses(value = {@ApiResponse(code = 405, message = POST_ERROR_MSG)})
-  public Response post() {
+  public Response postVersionContentsIsNotAllowed() {
     throw new MethodNotAllowedException(POST_ERROR_MSG);
   }
 
@@ -59,7 +59,7 @@ public class VersionContentsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve version contents")
   @ApiResponses(value = {@ApiResponse(code = 200, response = ResultVersion.class, message = "OK")})
-  public Response get(
+  public Response getVersionContents(
       @HeaderParam(ACCEPT_ENCODING) String acceptEncoding,
       @PathParam("versionId") @NotNull @Valid UUID versionId
   ) {
@@ -74,7 +74,7 @@ public class VersionContentsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = PUT_ERROR_MSG)
   @ApiResponses(value = {@ApiResponse(code = 405, message = PUT_ERROR_MSG)})
-  public Response put() {
+  public Response putVersionContentsIsNotAllowed() {
     throw new MethodNotAllowedException(PUT_ERROR_MSG);
   }
 
@@ -82,7 +82,7 @@ public class VersionContentsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = DELETE_ERROR_MSG)
   @ApiResponses(value = {@ApiResponse(code = 405, message = DELETE_ERROR_MSG)})
-  public Response delete() {
+  public Response deleteVersionContentsIsNotAllowed() {
     throw new MethodNotAllowedException(DELETE_ERROR_MSG);
   }
 

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/VersionMetadataResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/VersionMetadataResource.java
@@ -47,7 +47,7 @@ public class VersionMetadataResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = POST_ERROR_MSG)
   @ApiResponses(value = {@ApiResponse(code = 405, message = POST_ERROR_MSG)})
-  public Response post() {
+  public Response postVersionMetadataIsNotAllowed() {
     throw new MethodNotAllowedException(POST_ERROR_MSG);
   }
 
@@ -56,7 +56,7 @@ public class VersionMetadataResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve version metadata")
   @ApiResponses(value = {@ApiResponse(code = 200, responseContainer = "Map", response = String.class, message = "OK")})
-  public Response get(
+  public Response getVersionMetadata(
       @PathParam("versionId") @NotNull @Valid UUID versionId
   ) {
     log.debug("Get version metadata: versionId={}", versionId);
@@ -72,7 +72,7 @@ public class VersionMetadataResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create or update version metadata entry")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-  public Response put(
+  public Response putVersionMetadataEntry(
       @PathParam("versionId") @Valid UUID versionId,
       @PathParam("key") @NotNull String key,
       @NotNull String value
@@ -89,9 +89,9 @@ public class VersionMetadataResource {
   @Timed
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
-  @ApiOperation(value = "Delete document metadata entry")
+  @ApiOperation(value = "Delete version metadata entry")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-  public Response delete(
+  public Response deleteVersionMetadataEntry(
       @PathParam("versionId") @NotNull @Valid UUID versionId,
       @PathParam("key") @NotBlank String key
   ) {

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/VersionsResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/VersionsResource.java
@@ -51,7 +51,7 @@ public class VersionsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create version")
   @ApiResponses(value = {@ApiResponse(code = 200, response = ResultVersion.class, message = "OK")})
-  public Response post(
+  public Response createVersion(
       @FormDataParam("fileId") UUID fileId,
       @FormDataParam("contents") InputStream inputStream
   ) {
@@ -68,7 +68,7 @@ public class VersionsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Retrieve version")
   @ApiResponses(value = {@ApiResponse(code = 200, response = ResultVersion.class, message = "OK")})
-  public Response get(
+  public Response getVersion(
       @PathParam("id") @NotNull @Valid UUID id
   ) {
     log.debug("Get version: id={}", id);
@@ -83,7 +83,7 @@ public class VersionsResource {
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = PUT_ERROR_MSG)
   @ApiResponses(value = {@ApiResponse(code = 405, message = PUT_ERROR_MSG)})
-  public Response put(
+  public Response putVersionIsNotAllowed(
       @PathParam("id") @Valid UUID id,
       @Valid FormVersion form
   ) {
@@ -94,7 +94,7 @@ public class VersionsResource {
   @Path("/{id}")
   @ApiOperation(value = "Delete version")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
-  public Response delete(
+  public Response deleteVersion(
       @PathParam("id") @Valid UUID id
   ) {
     log.debug("Delete version: id={}", id);

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/task/DeleteDocumentResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/task/DeleteDocumentResource.java
@@ -30,7 +30,7 @@ public class DeleteDocumentResource {
   @ApiOperation(value = "Delete a document including its metadata, files, versions and contents. " +
       "Contents are only only deleted when not referenced by any other versions.")
   @Path("documents/{externalId}")
-  public Response deleteDocument(
+  public Response deleteDocumentRecursively(
       @NotBlank @PathParam("externalId") String externalId
   ) {
     log.debug("Delete document: externalId={}", externalId);

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/task/FindResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/task/FindResource.java
@@ -33,7 +33,6 @@ import static nl.knaw.huc.resources.HeaderLink.Uri.DOCUMENT_METADATA;
 import static nl.knaw.huc.resources.HeaderLink.Uri.FILE;
 import static nl.knaw.huc.resources.HeaderLink.Uri.FILE_METADATA;
 import static nl.knaw.huc.resources.HeaderLink.Uri.FILE_VERSIONS;
-import static javax.ws.rs.core.UriBuilder.fromResource;
 
 /**
  * The /find-task finds resources by external id and possible other parameters
@@ -62,7 +61,7 @@ public class FindResource {
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "OK"),
       @ApiResponse(code = 404, message = "Given document could not be found")})
-  public Response getDocumentMetadata(
+  public Response getDocumentMetadataForExternalId(
       @NotNull @PathParam("externalId") String externalId
   ) {
     log.debug("Find metadata of document: externalId={}", externalId);
@@ -89,7 +88,7 @@ public class FindResource {
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "OK"),
       @ApiResponse(code = 404, message = "Given file could not be found")})
-  public Response getFileMetadata(
+  public Response getFileMetadataForExternalId(
       @NotNull @PathParam("externalId") String externalId,
       @NotNull @QueryParam("type") String typeName
   ) {


### PR DESCRIPTION
When using swagger-codegen to generate python client code, I noticed some places where the returned class as defined in the swagger spec did not match the class that was actually returned, and I fixed the relevant @ApiOperation annotation values.
Also, the "actionId" field in the swagger spec must be unique for the whole API, and since in dropwizard-swagger it's generated from the @Api* annotated resource method name, these should be unique for the API.
I've renamed those methods where necessary.