### PR TITLE
Import task response fixes

### DIFF
--- a/concordion/src/test/resources/nl/knaw/huc/textrepo/task/TestIndexFilesByIndexName.md
+++ b/concordion/src/test/resources/nl/knaw/huc/textrepo/task/TestIndexFilesByIndexName.md
@@ -10,7 +10,7 @@ To index, we first create three documents, each with one file and version, using
 
 Then:
 
- - Response statuses should be: [200, 200, 200](- "?=#importResult.status");
+ - Response statuses should be: [201, 201, 201](- "?=#importResult.status");
  - Full response of first imported document:
 
 [ ](- "ext:embed=#importResult.body")

--- a/concordion/src/test/resources/nl/knaw/huc/textrepo/task/TestIndexFilesByType.md
+++ b/concordion/src/test/resources/nl/knaw/huc/textrepo/task/TestIndexFilesByType.md
@@ -10,7 +10,7 @@ To index, we first create three documents, each with one file and version, using
 
 Then:
 
- - Response statuses should be: [200, 200, 200](- "?=#importResult.status");
+ - Response statuses should be: [201, 201, 201](- "?=#importResult.status");
  - Full response of first imported document:
 
 [ ](- "ext:embed=#importResult.body")

--- a/textrepo-app/src/main/java/nl/knaw/huc/api/ResultImportDocument.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/api/ResultImportDocument.java
@@ -1,0 +1,37 @@
+package nl.knaw.huc.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import nl.knaw.huc.core.Document;
+import nl.knaw.huc.core.Version;
+
+import java.util.UUID;
+
+public class ResultImportDocument {
+  private final Document document;
+  private final Version version;
+
+  public ResultImportDocument(Document document, Version version) {
+    this.document = document;
+    this.version = version;
+  }
+
+  @JsonProperty
+  public UUID getDocumentId() {
+    return document.getId();
+  }
+  
+  @JsonProperty
+  public UUID getFileId() {
+    return version.getFileId();
+  }
+
+  @JsonProperty
+  public UUID getVersionId() {
+    return version.getId();
+  }
+
+  @JsonProperty
+  public String getContentsSha() {
+    return version.getContentsSha();
+  }
+}

--- a/textrepo-app/src/main/java/nl/knaw/huc/api/ResultImportDocument.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/api/ResultImportDocument.java
@@ -1,6 +1,7 @@
 package nl.knaw.huc.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import nl.knaw.huc.core.Document;
 import nl.knaw.huc.core.Version;
 
@@ -19,7 +20,7 @@ public class ResultImportDocument {
   public UUID getDocumentId() {
     return document.getId();
   }
-  
+
   @JsonProperty
   public UUID getFileId() {
     return version.getFileId();
@@ -33,5 +34,13 @@ public class ResultImportDocument {
   @JsonProperty
   public String getContentsSha() {
     return version.getContentsSha();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+                      .add("document", document)
+                      .add("version", version)
+                      .toString();
   }
 }

--- a/textrepo-app/src/main/java/nl/knaw/huc/api/ResultImportDocument.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/api/ResultImportDocument.java
@@ -10,10 +10,12 @@ import java.util.UUID;
 public class ResultImportDocument {
   private final Document document;
   private final Version version;
+  private final boolean isNewVersion;
 
-  public ResultImportDocument(Document document, Version version) {
+  public ResultImportDocument(Document document, Version version, boolean isNewVersion) {
     this.document = document;
     this.version = version;
+    this.isNewVersion = isNewVersion;
   }
 
   @JsonProperty
@@ -36,11 +38,17 @@ public class ResultImportDocument {
     return version.getContentsSha();
   }
 
+  @JsonProperty
+  public boolean isNewVersion() {
+    return isNewVersion;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
                       .add("document", document)
                       .add("version", version)
+                      .add("isNewVersion", isNewVersion)
                       .toString();
   }
 }

--- a/textrepo-app/src/main/java/nl/knaw/huc/db/VersionsDao.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/db/VersionsDao.java
@@ -27,7 +27,7 @@ public interface VersionsDao {
   Optional<Version> findLatestByFileId(@Bind UUID fileId);
 
   @SqlQuery("select id, file_id, created_at, contents_sha " +
-      "from versions where file_id = ? order by created_at asc")
+      "from versions where file_id = ? order by created_at desc")
   @RegisterConstructorMapper(value = Version.class)
   List<Version> findByFileId(UUID fileId);
 

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/HeaderLink.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/HeaderLink.java
@@ -1,15 +1,16 @@
 package nl.knaw.huc.resources;
 
+import nl.knaw.huc.resources.rest.ContentsResource;
 import nl.knaw.huc.resources.rest.DocumentMetadataResource;
 import nl.knaw.huc.resources.rest.DocumentsResource;
 import nl.knaw.huc.resources.rest.FileMetadataResource;
 import nl.knaw.huc.resources.rest.FileVersionsResource;
 import nl.knaw.huc.resources.rest.FilesResource;
 import nl.knaw.huc.resources.rest.TypesResource;
+import nl.knaw.huc.resources.rest.VersionsResource;
 
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.UriBuilder;
-
 import java.net.URI;
 
 import static javax.ws.rs.core.UriBuilder.fromResource;
@@ -23,12 +24,14 @@ public class HeaderLink {
   }
 
   public enum Uri {
-    DOCUMENT(fromResource(DocumentsResource.class).path("/{id}")),
+    CONTENTS(fromResource(ContentsResource.class).path("{sha}")),
+    DOCUMENT(fromResource(DocumentsResource.class).path("{id}")),
     DOCUMENT_METADATA(fromResource(DocumentMetadataResource.class)),
-    FILE(fromResource(FilesResource.class).path("/{id}")),
+    FILE(fromResource(FilesResource.class).path("{id}")),
     FILE_METADATA(fromResource(FileMetadataResource.class)),
     FILE_VERSIONS(fromResource(FileVersionsResource.class)),
-    TYPE(fromResource(TypesResource.class).path("/{id}"));
+    TYPE(fromResource(TypesResource.class).path("{id}")),
+    VERSION(fromResource(VersionsResource.class).path("{id}"));
 
     private final UriBuilder uriBuilder;
 

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/task/ImportResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/task/ImportResource.java
@@ -20,6 +20,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import java.io.InputStream;
 
 import static java.util.Objects.requireNonNull;
@@ -52,6 +53,7 @@ public class ImportResource {
       @NotBlank @PathParam("externalId") String externalId,
       @NotBlank @PathParam("typeName") String typeName,
       @QueryParam("allowNewDocument") @DefaultValue("false") boolean allowNewDocument,
+      @QueryParam("asLatestVersion") @DefaultValue("false") boolean asLatestVersion,
       @NotNull @FormDataParam("contents") InputStream uploadedInputStream,
       @NotNull @FormDataParam("contents") FormDataContentDisposition fileDetail
   ) {
@@ -59,27 +61,36 @@ public class ImportResource {
         "Importing document contents for file with type: " +
             "externalId={}, " +
             "typeName={}, " +
-            "allowNewDocument={}",
-        externalId, typeName, allowNewDocument
+            "allowNewDocument={}, " +
+            "asLatestVersion={}",
+        externalId, typeName, allowNewDocument, asLatestVersion
     );
 
-    final var builder = factory.getDocumentImportBuilder();
-    final var importTask = builder.allowNewDocument(allowNewDocument)
-                                  .forExternalId(externalId)
-                                  .withTypeName(typeName)
-                                  .forFilename(fileDetail.getFileName())
-                                  .withContents(uploadedInputStream)
-                                  .build();
+    final var importTask =
+        factory.getDocumentImportBuilder()
+               .allowNewDocument(allowNewDocument)
+               .asLatestVersion(asLatestVersion)
+               .forExternalId(externalId)
+               .withTypeName(typeName)
+               .forFilename(fileDetail.getFileName())
+               .withContents(uploadedInputStream)
+               .build();
 
     final var result = importTask.run();
     log.debug("Imported document contents: {}", result);
 
-    return Response.created(VERSION.build(result.getVersionId()))
-                   .entity(result)
-                   .link(CONTENTS.build(result.getContentsSha()), "contents")
-                   .link(DOCUMENT.build(result.getDocumentId()), "document")
-                   .link(FILE.build(result.getFileId()), "file")
-                   .link(VERSION.build(result.getVersionId()), "version")
-                   .build();
+    final ResponseBuilder builder;
+    if (result.isNewVersion()) {
+      builder = Response.created(VERSION.build(result.getVersionId()));
+    } else {
+      builder = Response.ok();
+    }
+
+    return builder.entity(result)
+                  .link(CONTENTS.build(result.getContentsSha()), "contents")
+                  .link(DOCUMENT.build(result.getDocumentId()), "document")
+                  .link(FILE.build(result.getFileId()), "file")
+                  .link(VERSION.build(result.getVersionId()), "version")
+                  .build();
   }
 }

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/task/ImportResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/task/ImportResource.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import nl.knaw.huc.resources.rest.VersionsResource;
 import nl.knaw.huc.service.task.TaskBuilderFactory;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
@@ -20,6 +21,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import java.io.InputStream;
 
 import static java.util.Objects.requireNonNull;
@@ -67,8 +69,15 @@ public class ImportResource {
                                   .withContents(uploadedInputStream)
                                   .build();
 
-    importTask.run();
+    final var result = importTask.run();
     log.debug("Imported document contents");
-    return Response.ok().build();
+    final var location = UriBuilder.fromResource(VersionsResource.class)
+                                   .path("{id}")
+                                   .build(result.getVersionId());
+    log.debug("Version URI: [{}]", location);
+
+    return Response.created(location)
+                   .entity(result)
+                   .build();
   }
 }

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/task/ImportResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/task/ImportResource.java
@@ -74,8 +74,7 @@ public class ImportResource {
     final var result = importTask.run();
     log.debug("Imported document contents: {}", result);
 
-    final var location = VERSION.build(result.getVersionId());
-    return Response.created(location)
+    return Response.created(VERSION.build(result.getVersionId()))
                    .entity(result)
                    .link(CONTENTS.build(result.getContentsSha()), "contents")
                    .link(DOCUMENT.build(result.getDocumentId()), "document")

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/task/SetFileContents.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/task/SetFileContents.java
@@ -14,29 +14,30 @@ import java.util.function.Supplier;
 import static java.time.LocalDateTime.now;
 import static java.util.Objects.requireNonNull;
 
-public class SetCurrentFileContents implements InTransactionProvider<Version> {
+public class SetFileContents implements InTransactionProvider<Version> {
 
-  private final Supplier<UUID> versionIdGenerator;
-  
+  private final Supplier<UUID> idGenerator;
+
   private final TextRepoFile file;
   private final Contents contents;
+  private final boolean asLatestVersion;
 
   private Handle transaction;
 
-  public SetCurrentFileContents(
-      Supplier<UUID> versionIdGenerator,
-      TextRepoFile file,
-      Contents contents
-  ) {
-    this.versionIdGenerator = requireNonNull(versionIdGenerator);
+  public SetFileContents(Supplier<UUID> idGenerator, TextRepoFile file, Contents contents, boolean asLatestVersion) {
+    this.idGenerator = requireNonNull(idGenerator);
     this.file = requireNonNull(file);
     this.contents = requireNonNull(contents);
+    this.asLatestVersion = asLatestVersion;
   }
 
   @Override
   public Version executeIn(Handle transaction) {
     this.transaction = requireNonNull(transaction);
-    return latestVersionIfIdentical().orElseGet(this::createNewVersionWithContents);
+    if (asLatestVersion) {
+      return latestVersionIfIdentical().orElseGet(this::createNewVersionWithContents);
+    }
+    return anyVersionIfIdentical().orElseGet(this::createNewVersionWithContents);
   }
 
   private Optional<Version> latestVersionIfIdentical() {
@@ -44,12 +45,18 @@ public class SetCurrentFileContents implements InTransactionProvider<Version> {
                      .filter(this::hasIdenticalContents);
   }
 
+  private Optional<Version> anyVersionIfIdentical() {
+    return versions().findByFileId(file.getId()).stream()
+                     .filter(this::hasIdenticalContents)
+                     .findFirst();
+  }
+
   private boolean hasIdenticalContents(Version candidate) {
     return candidate.getContentsSha().equals(contents.getSha224());
   }
 
   private Version createNewVersionWithContents() {
-    final var id = versionIdGenerator.get();
+    final var id = idGenerator.get();
     final var version = new Version(id, file.getId(), contents.getSha224(), now());
     contents().insert(contents);
     versions().insert(version);

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/task/importer/ImportFileTaskBuilder.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/task/importer/ImportFileTaskBuilder.java
@@ -8,6 +8,8 @@ import java.io.InputStream;
 public interface ImportFileTaskBuilder {
   ImportFileTaskBuilder allowNewDocument(boolean allowNewDocument);
 
+  ImportFileTaskBuilder asLatestVersion(boolean asLatestVersion);
+
   ImportFileTaskBuilder forExternalId(String externalId);
 
   ImportFileTaskBuilder withTypeName(String type);

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/task/importer/ImportFileTaskBuilder.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/task/importer/ImportFileTaskBuilder.java
@@ -1,6 +1,6 @@
 package nl.knaw.huc.service.task.importer;
 
-import nl.knaw.huc.core.Version;
+import nl.knaw.huc.api.ResultImportDocument;
 import nl.knaw.huc.service.task.Task;
 
 import java.io.InputStream;
@@ -16,5 +16,5 @@ public interface ImportFileTaskBuilder {
 
   ImportFileTaskBuilder withContents(InputStream inputStream);
 
-  Task<Version> build();
+  Task<ResultImportDocument> build();
 }


### PR DESCRIPTION
Status codes:
- `200 OK` when no version was created;
- `201 CREATED` and (absolute) uri of version in HTTP `Location` header when new version was created;

HTTP `Link` headers for Document, File, Version and Contents as well as json body in both `200` and `201` cases.

New query param `asLatestVersion` determines whether it is ok if the currently uploaded file already exists as _any_ version or whether it has to be the _latest_ version.

If any version is ok, no new version will be made if contents of current upload are already available as any version of this file.

if `asLatestVersion` is requested, new version will be made of this contents, **unless** these contents are already the current latest version.