### PR TITLE
File index updates

### DIFF
--- a/elasticsearch/file/file-mapping.json
+++ b/elasticsearch/file/file-mapping.json
@@ -2,7 +2,9 @@
   "mappings": {
     "dynamic": false,
     "properties": {
-
+      "indexedOn": {
+        "type": "date"
+      },
       "file": {
         "properties": {
           "id": {

--- a/elasticsearch/file/src/main/java/nl/knaw/huc/api/ResultFields.java
+++ b/elasticsearch/file/src/main/java/nl/knaw/huc/api/ResultFields.java
@@ -2,7 +2,10 @@ package nl.knaw.huc.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import static java.time.LocalDateTime.now;
 
 public class ResultFields {
 
@@ -10,8 +13,10 @@ public class ResultFields {
   private ResultDoc doc;
   private List<ResultVersion> versions;
   private ResultContentsLastModified contentsLastModified;
+  private LocalDateTime indexedOn;
 
   public ResultFields() {
+    indexedOn = now();
   }
 
   @JsonProperty
@@ -48,5 +53,10 @@ public class ResultFields {
 
   public void setContentsLastModified(ResultContentsLastModified contentsLastModified) {
     this.contentsLastModified = contentsLastModified;
+  }
+
+  @JsonProperty
+  public LocalDateTime getIndexedOn() {
+    return indexedOn;
   }
 }

--- a/textrepo-app/src/main/java/nl/knaw/huc/db/FilesDao.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/db/FilesDao.java
@@ -4,9 +4,11 @@ import nl.knaw.huc.core.TextRepoFile;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -22,6 +24,9 @@ public interface FilesDao {
   @SqlQuery("select id, type_id from files where type_id = :typeId")
   @RegisterConstructorMapper(value = TextRepoFile.class)
   void foreachByType(@Bind("typeId") short typeId, Consumer<TextRepoFile> consumer);
+
+  @SqlQuery("select count(id) from files where type_id in (<typeIds>)")
+  long countByTypes(@BindList("typeIds") List<Short> typeIds);
 
   @SqlUpdate("insert into files (id, type_id) values (:id, :typeId) " +
       "on conflict (id) do update set type_id = excluded.type_id")

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/index/MappedIndexer.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/index/MappedIndexer.java
@@ -44,15 +44,15 @@ import static org.elasticsearch.common.xcontent.XContentType.JSON;
  * - GET `mapping`
  * - POST `fields`. Files can be posted in two ways:
  * - `original`, POST request with:
- * - content-type header with file mimetype
- * - link header with rel=origin and url to file resource
- * - body containing the file
+ *    - content-type header with file mimetype
+ *    - link header with rel=origin and url to file resource
+ *    - body containing the file
  * - `multipart`, POST request with:
- * - content-type header with 'multipart/form-data'
- * - body part named 'file' with:
- * - content-type header with file mimetype.
- * - link header with rel=origin and url to file resource
- * - file contents
+ *    - content-type header with 'multipart/form-data'
+ *    - body part named 'file' with:
+ *      - content-type header with file mimetype.
+ *      - link header with rel=origin and url to file resource
+ *      - file contents
  * MappedFileIndexer is configured in config.yml
  */
 public class MappedIndexer implements Indexer {

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/index/MappedIndexer.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/index/MappedIndexer.java
@@ -44,15 +44,15 @@ import static org.elasticsearch.common.xcontent.XContentType.JSON;
  * - GET `mapping`
  * - POST `fields`. Files can be posted in two ways:
  * - `original`, POST request with:
- *    - content-type header with file mimetype
- *    - link header with rel=origin and url to file resource
- *    - body containing the file
+ * - content-type header with file mimetype
+ * - link header with rel=origin and url to file resource
+ * - body containing the file
  * - `multipart`, POST request with:
- *    - content-type header with 'multipart/form-data'
- *    - body part named 'file' with:
- *      - content-type header with file mimetype.
- *      - link header with rel=origin and url to file resource
- *      - file contents
+ * - content-type header with 'multipart/form-data'
+ * - body part named 'file' with:
+ * - content-type header with file mimetype.
+ * - link header with rel=origin and url to file resource
+ * - file contents
  * MappedFileIndexer is configured in config.yml
  */
 public class MappedIndexer implements Indexer {
@@ -115,9 +115,9 @@ public class MappedIndexer implements Indexer {
     var response = getFields(latestVersionContents, mimetype, file.getId());
     var esFacets = response.readEntity(String.class);
 
-    var fieldStatusComplaint = checkFieldStatus(response, esFacets);
-    if (fieldStatusComplaint.isPresent()) {
-      return fieldStatusComplaint;
+    var error = checkIndexerResponseStatus(response, esFacets);
+    if (error.isPresent()) {
+      return error;
     }
 
     return sendRequest(file.getId(), esFacets);
@@ -194,16 +194,7 @@ public class MappedIndexer implements Indexer {
         .id(fileId.toString())
         .source(esFacets, JSON);
     var response = indexRequest(indexRequest);
-    var status = response.status().getStatus();
-    if (status == 201) {
-      log.debug("Successfully added file [{}] to index [{}]", fileId, config.elasticsearch.index);
-      return Optional.empty();
-    } else {
-      final var msg = format("Response of adding file %s to index %s was: %d - %s",
-          fileId, config.elasticsearch.index, status, response.toString());
-      log.error(msg);
-      return Optional.of(msg);
-    }
+    return checkEsResponseStatus(response, fileId);
   }
 
   private IndexResponse indexRequest(IndexRequest indexRequest) {
@@ -224,10 +215,38 @@ public class MappedIndexer implements Indexer {
     return true;
   }
 
-  private Optional<String> checkFieldStatus(Response response, String esFacets) {
+  /**
+   * When not 200 or 201, return error msg
+   */
+  private Optional<String> checkEsResponseStatus(IndexResponse response, UUID fileId) {
+    var status = response.status().getStatus();
+    var index = config.elasticsearch.index;
+
+    if (status == 201) {
+      log.debug("Successfully added file [{}] to index [{}]", fileId, index);
+      return Optional.empty();
+    } else if (status == 200) {
+      log.debug("Successfully updated file [{}] to index [{}]", fileId, index);
+      return Optional.empty();
+    } else {
+      var msg = format(
+          "Response of adding file %s to index %s was: %d - %s",
+          fileId, index, status, response.toString()
+      );
+      log.error(msg);
+      return Optional.of(msg);
+    }
+  }
+
+  /**
+   * When not 200, return error msg
+   */
+  private Optional<String> checkIndexerResponseStatus(Response response, String esBody) {
     if (response.getStatus() != 200) {
-      final var msg = format("Could not get fields for %s, response was: %d - %s",
-          config.elasticsearch.index, response.getStatus(), esFacets);
+      final var msg = format(
+          "Could not get fields for %s, response was: %d - %s",
+          config.elasticsearch.index, response.getStatus(), esBody
+      );
       log.error(msg);
       return Optional.of(msg);
     }

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/task/indexer/JdbiIndexFileTaskBuilder.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/task/indexer/JdbiIndexFileTaskBuilder.java
@@ -21,10 +21,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static com.google.common.primitives.Shorts.asList;
 import static java.lang.String.format;
+import static java.util.List.of;
 import static java.util.Objects.requireNonNull;
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 
 public class JdbiIndexFileTaskBuilder implements IndexFileTaskBuilder {
   private static final Logger log = LoggerFactory.getLogger(JdbiIndexFileTaskBuilder.class);
@@ -140,7 +139,7 @@ public class JdbiIndexFileTaskBuilder implements IndexFileTaskBuilder {
     }
 
     private void indexFilesByType(Short typeId) {
-      filesTotal += jdbi.onDemand(FilesDao.class).countByTypes(asList(typeId));
+      filesTotal += jdbi.onDemand(FilesDao.class).countByTypes(of(typeId));
       jdbi.onDemand(FilesDao.class).foreachByType(typeId, this::indexFile);
     }
 

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/task/indexer/JdbiIndexFileTaskBuilder.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/task/indexer/JdbiIndexFileTaskBuilder.java
@@ -36,9 +36,9 @@ public class JdbiIndexFileTaskBuilder implements IndexFileTaskBuilder {
   private String typeName;
   private String indexName;
 
-  private int filesAffected = 0;
-  private int filesTotal = -1;
-  
+  private long filesAffected = 0;
+  private long filesTotal = -1;
+
   public JdbiIndexFileTaskBuilder(Jdbi jdbi, List<Indexer> indexers) {
     this.jdbi = requireNonNull(jdbi);
     this.indexers = requireNonNull(indexers);
@@ -189,7 +189,7 @@ public class JdbiIndexFileTaskBuilder implements IndexFileTaskBuilder {
             );
           });
 
-      typesToIndex.forEach(tti -> filesTotal += jdbi.onDemand(FilesDao.class).countByTypes(typesToIndex));
+      filesTotal = jdbi.onDemand(FilesDao.class).countByTypes(typesToIndex);
       typesToIndex.forEach(this::indexFilesByType);
 
       final var msg = format("Total files affected: %d", filesAffected);


### PR DESCRIPTION
Small changes and fixes in indexing process:
- log the file status including count on INFO instead of DEBUG level
- add indexedOn field to file indexer
- handle `200 updated` (instead of `201 created`) ES response not as an error