### PR TITLE
Fix: Add env var with nginx es host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Do not forget to include:
  - Changes in the environment variables
  - Changes to the database
 
+## [1.16.2]
+
+### Changed
+Link to elasticsearch service using container name `tr_elasticsearch:9200`
+
+### Added
+- Environment variables: NGINX_ES_HOST
+
 ## [1.14.0]
 
 ### Changed

--- a/elasticsearch/spacy-ner/README.md
+++ b/elasticsearch/spacy-ner/README.md
@@ -19,7 +19,7 @@ Text repository indexer that recognizes named entities using spacy, flask and do
       - ./elasticsearch/spacy-ner/model:/indexer/model
       - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "/indexer/wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "/indexer/wait-for-it.sh", "tr_elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
 ```
@@ -36,7 +36,7 @@ Text repository indexer that recognizes named entities using spacy, flask and do
   elasticsearch:
     index: spacy-ner
     hosts:
-      - elasticsearch:9200
+      - tr_elasticsearch:9200
 ```
 
 - Check service is running: 

--- a/examples/development/docker-compose-dev.yml
+++ b/examples/development/docker-compose-dev.yml
@@ -64,6 +64,7 @@ services:
       NGINX_LISTEN: ${NGINX_LISTEN}
       NGINX_LOCATION: ${NGINX_LOCATION}
       CONCORDION_ROOT_REDIRECT: ${CONCORDION_ROOT_REDIRECT}
+      NGINX_ES_HOST: ${NGINX_ES_HOST}
 
   autocomplete-indexer:
     container_name: tr_autocomplete
@@ -79,7 +80,7 @@ services:
     volumes:
     - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "./wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "./wait-for-it.sh", "tr_elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
 
@@ -97,7 +98,7 @@ services:
     volumes:
       - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "./wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "./wait-for-it.sh", "tr_elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
 
@@ -115,7 +116,7 @@ services:
     volumes:
       - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "./wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "./wait-for-it.sh", "tr_elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
 

--- a/examples/development/docker-compose.env
+++ b/examples/development/docker-compose.env
@@ -45,7 +45,7 @@ export TR_INDEXERS='
   elasticsearch:
     index: autocomplete
     hosts:
-      - elasticsearch:9200
+      - tr_elasticsearch:9200
 - name: full-text
   mapping: http://full-text-indexer:8080/full-text/mapping
   fields:
@@ -57,7 +57,7 @@ export TR_INDEXERS='
   elasticsearch:
     index: full-text
     hosts:
-      - elasticsearch:9200
+      - tr_elasticsearch:9200
 - name: file
   mapping: http://file-indexer:8080/file/mapping
   fields:
@@ -72,7 +72,7 @@ export TR_INDEXERS='
   elasticsearch:
     index: file
     hosts:
-      - elasticsearch:9200'
+      - tr_elasticsearch:9200'
 
 export TR_SWAGGER_RESOURCE_PACKAGE=nl.knaw.huc.resources
 export TR_SWAGGER_CONTEXT_ROOT=/textrepo
@@ -97,6 +97,7 @@ export NGINX_LOCATION=/textrepo/
 export NGINX_VIRTUAL_HOST=localhost:8080
 export NGINX_VIRTUAL_HOST_SCHEME=http://
 export NGINX_LISTEN=8080
+export NGINX_ES_HOST=tr_elasticsearch:9200
 
 export ES_NODE_NAME=es01
 export ES_CLUSTER_INITIAL_MASTER_NODES=es01
@@ -104,7 +105,7 @@ export ES_CLUSTER_NAME=textrepo-cluster
 export ES_BOOTSTRAP_MEMORY_LOCK=true
 export ES_JAVA_OPTS='-Xms512m -Xmx512m'
 
-export CONCORDION_ES_HOST=elasticsearch:9200
+export CONCORDION_ES_HOST=tr_elasticsearch:9200
 export CONCORDION_APP_HOST=textrepo-app:8080
 export CONCORDION_APP_HOST_ADMIN=textrepo-app:8081
 export CONCORDION_ROOT_REDIRECT=/concordion/nl/knaw/huc/textrepo/TextRepo.html

--- a/examples/production/docker-compose-integration.yml
+++ b/examples/production/docker-compose-integration.yml
@@ -61,6 +61,7 @@ services:
       NGINX_LISTEN: ${NGINX_LISTEN}
       NGINX_LOCATION: ${NGINX_LOCATION}
       CONCORDION_ROOT_REDIRECT: ${CONCORDION_ROOT_REDIRECT}
+      NGINX_ES_HOST: ${NGINX_ES_HOST}
 
   autocomplete-indexer:
     container_name: tr_autocomplete
@@ -75,7 +76,7 @@ services:
     volumes:
       - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "./wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "./wait-for-it.sh", "tr_elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
 
@@ -92,7 +93,7 @@ services:
     volumes:
       - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "./wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "./wait-for-it.sh", "tr_elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
 
@@ -109,7 +110,7 @@ services:
     volumes:
       - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "./wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "./wait-for-it.sh", "tr_elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
 

--- a/examples/production/docker-compose-prod.yml
+++ b/examples/production/docker-compose-prod.yml
@@ -61,6 +61,7 @@ services:
       NGINX_LISTEN: ${NGINX_LISTEN}
       NGINX_LOCATION: ${NGINX_LOCATION}
       CONCORDION_ROOT_REDIRECT: ${CONCORDION_ROOT_REDIRECT}
+      NGINX_ES_HOST: ${NGINX_ES_HOST}
 
   autocomplete-indexer:
     container_name: tr_autocomplete
@@ -75,7 +76,7 @@ services:
     volumes:
     - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "./wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "./wait-for-it.sh", "tr_elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
 
@@ -92,7 +93,7 @@ services:
     volumes:
       - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "./wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "./wait-for-it.sh", "tr_elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
 
@@ -109,7 +110,7 @@ services:
     volumes:
       - ./scripts/wait-for-it.sh:/indexer/wait-for-it.sh
     command: [
-        "./wait-for-it.sh", "elasticsearch:9200", "--timeout=0", "--",
+        "./wait-for-it.sh", "tr_elasticsearch:9200", "--timeout=0", "--",
         "./start.sh"
     ]
 

--- a/examples/production/docker-compose.env
+++ b/examples/production/docker-compose.env
@@ -39,7 +39,7 @@ export TR_INDEXERS='
   elasticsearch:
     index: autocomplete
     hosts:
-      - elasticsearch:9200
+      - tr_elasticsearch:9200
 - name: full-text
   mapping: http://full-text-indexer:8080/full-text/mapping
   fields:
@@ -51,7 +51,7 @@ export TR_INDEXERS='
   elasticsearch:
     index: full-text
     hosts:
-      - elasticsearch:9200
+      - tr_elasticsearch:9200
 - name: file
   mapping: http://file-indexer:8080/file/mapping
   fields:
@@ -66,7 +66,7 @@ export TR_INDEXERS='
   elasticsearch:
     index: file
     hosts:
-      - elasticsearch:9200'
+      - tr_elasticsearch:9200'
 
 export TR_SWAGGER_RESOURCE_PACKAGE=nl.knaw.huc.resources
 export TR_SWAGGER_CONTEXT_ROOT=/textrepo
@@ -91,6 +91,7 @@ export NGINX_LOCATION=/textrepo/
 export NGINX_VIRTUAL_HOST=localhost:8080
 export NGINX_VIRTUAL_HOST_SCHEME=http://
 export NGINX_LISTEN=8080
+export NGINX_ES_HOST=tr_elasticsearch:9200
 
 export ES_NODE_NAME=es01
 export ES_CLUSTER_INITIAL_MASTER_NODES=es01
@@ -98,7 +99,7 @@ export ES_CLUSTER_NAME=textrepo-cluster
 export ES_BOOTSTRAP_MEMORY_LOCK=true
 export ES_JAVA_OPTS='-Xms512m -Xmx512m'
 
-export CONCORDION_ES_HOST=elasticsearch:9200
+export CONCORDION_ES_HOST=tr_elasticsearch:9200
 export CONCORDION_APP_HOST=textrepo-app:8080
 export CONCORDION_APP_HOST_ADMIN=textrepo-app:8081
 export CONCORDION_ROOT_REDIRECT=/concordion/nl/knaw/huc/textrepo/TextRepo.html

--- a/kubernetes/03-textrepo-app.yaml
+++ b/kubernetes/03-textrepo-app.yaml
@@ -30,7 +30,7 @@ spec:
       - args:
         - /scripts/wait-for-it.sh
         - postgres:5432
-        - elasticsearch:9200
+        - tr_elasticsearch:9200
         - --timeout=0
         - --
         - java

--- a/kubernetes/05-concordion.yml
+++ b/kubernetes/05-concordion.yml
@@ -42,7 +42,7 @@ spec:
         - name: APP_HOST
           value: textrepo-app:8080
         - name: ES_HOST
-          value: elasticsearch:9200
+          value: tr_elasticsearch:9200
         - name: POSTGRES_HOST
           value: postgres
         - name: POSTGRES_DB

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,7 +20,7 @@ http {
       proxy_pass http://textrepo-app:8081/healthcheck;
     }
     location /index/ {
-      proxy_pass http://elasticsearch:9200/;
+      proxy_pass http://${NGINX_ES_HOST}/;
     }
     location /concordion/ {
       autoindex on;


### PR DESCRIPTION
In production the current setup results in a mixup with another `elasticsearch:9200` service, because two different docker-compose setups (using the same network) have an `elasticsearch` service. 
To prevent the textrepo services using the elasticsearch service of another setup:
1. Add env var `NGINX_ES_HOST` to specify where es is running
2. Use the more project specific `tr_elasticsearch` container name 
