### PR TITLE
Fix contents fk handling

### DIFF
--- a/textrepo-app/src/main/java/nl/knaw/huc/helpers/Paginator.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/helpers/Paginator.java
@@ -33,10 +33,11 @@ public class Paginator {
   }
 
   public static <T, U> ResultPage<U> toResult(Page<T> page, Function<T, U> mapper) {
-    var resultContent = page.getItems()
-                            .stream()
-                            .map(mapper)
-                            .collect(toList());
+    var resultContent = page
+        .getItems()
+        .stream()
+        .map(mapper)
+        .collect(toList());
     var resultParams = new ResultPageParams(
         page.getParams().getLimit(),
         page.getParams().getOffset()

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/task/DeleteDocumentResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/task/DeleteDocumentResource.java
@@ -10,9 +10,11 @@ import javax.validation.constraints.NotBlank;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
 import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Api(tags = {"task", "documents"})
 @Path("/task/delete")
@@ -30,6 +32,7 @@ public class DeleteDocumentResource {
   @ApiOperation(value = "Delete a document including its metadata, files, versions and contents. " +
       "Contents are only deleted when not referenced by any other versions.")
   @Path("documents/{externalId}")
+  @Produces(APPLICATION_JSON)
   public Response deleteDocumentRecursively(
       @NotBlank @PathParam("externalId") String externalId
   ) {

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/view/TextViewerResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/view/TextViewerResource.java
@@ -13,10 +13,13 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.HttpHeaders.ACCEPT_ENCODING;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 
 /*
@@ -49,6 +52,7 @@ public class TextViewerResource {
 
   @GET
   @Path("chars/{startOffset}/{endOffset}")
+  @Produces(TEXT_PLAIN)
   public Response getChars(
       @HeaderParam(ACCEPT_ENCODING) String acceptEncoding,
       @PathParam("startOffset") @NotNull RangeParam startParam,
@@ -64,6 +68,7 @@ public class TextViewerResource {
 
   @GET
   @Path("lines/{startOffset}/{endOffset}")
+  @Produces(TEXT_PLAIN)
   public Response getLines(
       @HeaderParam(ACCEPT_ENCODING) String acceptEncoding,
       @PathParam("startOffset") @NotNull RangeParam startParam,
@@ -80,6 +85,7 @@ public class TextViewerResource {
   @GET
   @Path("range/{startLineOffset}/{startCharOffset}/{endLineOffset}/{endCharOffset}")
   // E.g., from line 3, char 12 (on that line) up to and including line 8, char 4 (on that line)
+  @Produces(TEXT_PLAIN)
   public Response getRange(
       @HeaderParam(ACCEPT_ENCODING) String acceptEncoding,
       @PathParam("startLineOffset") @NotNull RangeParam startLineParam,

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/index/MappedIndexer.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/index/MappedIndexer.java
@@ -1,7 +1,7 @@
 package nl.knaw.huc.service.index;
 
 import nl.knaw.huc.core.TextRepoFile;
-import nl.knaw.huc.resources.HeaderLink;
+import nl.knaw.huc.service.index.request.IndexerFieldsRequestFactory;
 import nl.knaw.huc.service.type.TypeService;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.index.IndexRequest;
@@ -9,9 +9,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.glassfish.jersey.media.multipart.FormDataBodyPart;
-import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,7 +17,6 @@ import javax.annotation.Nonnull;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.Optional;
@@ -28,32 +24,22 @@ import java.util.UUID;
 
 import static java.lang.String.format;
 import static java.lang.String.join;
-import static javax.ws.rs.client.Entity.entity;
-import static nl.knaw.huc.resources.HeaderLink.Rel.ORIGINAL;
-import static nl.knaw.huc.resources.HeaderLink.Uri.FILE;
 import static nl.knaw.huc.service.index.FieldsType.MULTIPART;
 import static org.elasticsearch.common.xcontent.XContentType.JSON;
 
 /**
- * MappedFileIndexer creates its index in elasticsearch:
- * - as defined by its es-mapping which can be retrieved at its `mapping` endpoint
- * MappedFileIndexer adds new files to its index:
- * - convert file contents to an es-doc at its `fields` endpoint
- * - sends index-request with es-doc to its index
- * MappedFileIndexer depends on a REST-service with the following two endpoints:
+ * MappedFileIndexer creates its index in elasticsearch as defined by its es-mapping
+ * which can be retrieved at its `mapping` endpoint
+ *
+ * <p>MappedFileIndexer adds new files to its index in two steps:
+ * 1. convert file contents to an es-doc at its `fields` endpoint
+ * 2. sends index-request with es-doc to its index
+ *
+ * <p>MappedFileIndexer depends on a REST-service with the following two endpoints:
  * - GET `mapping`
- * - POST `fields`. Files can be posted in two ways:
- * - `original`, POST request with:
- *    - content-type header with file mimetype
- *    - link header with rel=origin and url to file resource
- *    - body containing the file
- * - `multipart`, POST request with:
- *    - content-type header with 'multipart/form-data'
- *    - body part named 'file' with:
- *      - content-type header with file mimetype.
- *      - link header with rel=origin and url to file resource
- *      - file contents
- * MappedFileIndexer is configured in config.yml
+ * - POST `fields`
+ *
+ * <p>MappedFileIndexer is configured in config.yml
  */
 public class MappedIndexer implements Indexer {
 
@@ -62,6 +48,7 @@ public class MappedIndexer implements Indexer {
   private final Client requestClient = JerseyClientBuilder.newClient();
   private final TypeService typeService;
   private final TextRepoElasticClient client;
+  private final IndexerFieldsRequestFactory fieldsRequestFactory;
 
   public MappedIndexer(
       MappedIndexerConfiguration config,
@@ -70,6 +57,7 @@ public class MappedIndexer implements Indexer {
     this.config = config;
     this.typeService = typeService;
     this.client = new TextRepoElasticClient(config.elasticsearch);
+    this.fieldsRequestFactory = new IndexerFieldsRequestFactory(config.fields.url, this.requestClient);
 
     createIndex(config);
     if (MULTIPART.equals(config.fields.type)) {
@@ -142,51 +130,9 @@ public class MappedIndexer implements Indexer {
   }
 
   private Response getFields(@Nonnull String latestVersionContents, String mimetype, UUID fileId) {
-    switch (config.fields.type) {
-      case ORIGINAL:
-        return getFieldsOriginal(latestVersionContents, mimetype, fileId);
-      case MULTIPART:
-        return getFieldsMultipart(latestVersionContents, mimetype, fileId);
-      default:
-        throw new IllegalStateException(format(
-            "Fields type [%s] of [%s] does not exist",
-            config.elasticsearch.index,
-            config.fields.type
-        ));
-    }
-  }
-
-  private Response getFieldsOriginal(@Nonnull String latestVersionContents, String mimetype, UUID fileId) {
-    return requestClient
-        .target(config.fields.url)
-        .request()
-        .header("Link", HeaderLink.create(ORIGINAL, FILE, fileId))
-        .post(entity(latestVersionContents, mimetype));
-  }
-
-  private Response getFieldsMultipart(@Nonnull String latestVersionContents, String mimetype, UUID fileId) {
-    return postMultipart(latestVersionContents.getBytes(), mimetype, fileId);
-  }
-
-  private Response postMultipart(byte[] bytes, String mimetype, UUID fileId) {
-    var contentDisposition = FormDataContentDisposition
-        .name("file")
-        .size(bytes.length)
-        .build();
-
-    var bodyPart = new FormDataBodyPart(contentDisposition, bytes, MediaType.valueOf(mimetype));
-    var originLink = HeaderLink.create(ORIGINAL, FILE, fileId).toString();
-    bodyPart.getHeaders().add("Link", originLink);
-
-    var multiPart = new FormDataMultiPart().bodyPart(bodyPart);
-
-    var request = requestClient
-        .target(config.fields.url)
-        .request();
-
-    var entity = entity(multiPart, multiPart.getMediaType());
-
-    return request.post(entity);
+    return fieldsRequestFactory
+        .build(config.fields.type)
+        .requestFields(latestVersionContents, mimetype, fileId);
   }
 
   private Optional<String> sendRequest(@Nonnull UUID fileId, String esFacets) {

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/index/request/IndexerFieldsRequest.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/index/request/IndexerFieldsRequest.java
@@ -1,0 +1,13 @@
+package nl.knaw.huc.service.index.request;
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.core.Response;
+import java.util.UUID;
+
+public interface IndexerFieldsRequest {
+  Response requestFields(
+      @Nonnull String contents,
+      @Nonnull String mimetype,
+      @Nonnull UUID fileId
+  );
+}

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/index/request/IndexerFieldsRequestFactory.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/index/request/IndexerFieldsRequestFactory.java
@@ -1,0 +1,28 @@
+package nl.knaw.huc.service.index.request;
+
+import nl.knaw.huc.service.index.FieldsType;
+
+import javax.ws.rs.client.Client;
+
+import static java.lang.String.format;
+
+public class IndexerFieldsRequestFactory {
+  private final String url;
+  private final Client client;
+
+  public IndexerFieldsRequestFactory(String url, Client client) {
+    this.url = url;
+    this.client = client;
+  }
+
+  public IndexerFieldsRequest build(FieldsType type) {
+    switch (type) {
+      case ORIGINAL:
+        return new OriginalIndexerFieldsRequest(url, client);
+      case MULTIPART:
+        return new MultipartIndexerFieldsRequest(url, client);
+      default:
+        throw new IllegalStateException(format("Request type [%s] of does not exist", type));
+    }
+  }
+}

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/index/request/MultipartIndexerFieldsRequest.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/index/request/MultipartIndexerFieldsRequest.java
@@ -1,0 +1,64 @@
+package nl.knaw.huc.service.index.request;
+
+import nl.knaw.huc.resources.HeaderLink;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.UUID;
+
+import static javax.ws.rs.client.Entity.entity;
+import static nl.knaw.huc.resources.HeaderLink.Rel.ORIGINAL;
+import static nl.knaw.huc.resources.HeaderLink.Uri.FILE;
+
+/**
+ * Post a file to ./fields with a `multipart/form-data` Content-Type header
+ * and a multipart body part named "file" which contains:
+ *   - file contents
+ *   - Content-Type header with file mimetype
+ */
+public class MultipartIndexerFieldsRequest implements IndexerFieldsRequest {
+
+  private final String url;
+  private final Client client;
+
+  public MultipartIndexerFieldsRequest(String url, Client client) {
+    this.url = url;
+    this.client = client;
+  }
+
+  @Override
+  public Response requestFields(
+      @Nonnull String contents,
+      @Nonnull String mimetype,
+      @Nonnull UUID fileId
+  ) {
+    return postMultipart(contents.getBytes(), mimetype, fileId);
+  }
+
+  private Response postMultipart(byte[] bytes, String mimetype, UUID fileId) {
+    var contentDisposition = FormDataContentDisposition
+        .name("file")
+        .size(bytes.length)
+        .build();
+
+    var bodyPart = new FormDataBodyPart(contentDisposition, bytes, MediaType.valueOf(mimetype));
+    var originLink = HeaderLink.create(ORIGINAL, FILE, fileId).toString();
+    bodyPart.getHeaders().add("Link", originLink);
+
+    var multiPart = new FormDataMultiPart().bodyPart(bodyPart);
+
+    var request = client
+        .target(url)
+        .request();
+
+    var entity = entity(multiPart, multiPart.getMediaType());
+    return request.post(entity);
+  }
+
+
+}

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/index/request/OriginalIndexerFieldsRequest.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/index/request/OriginalIndexerFieldsRequest.java
@@ -1,0 +1,40 @@
+package nl.knaw.huc.service.index.request;
+
+import nl.knaw.huc.resources.HeaderLink;
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import java.util.UUID;
+
+import static javax.ws.rs.client.Entity.entity;
+import static nl.knaw.huc.resources.HeaderLink.Rel.ORIGINAL;
+import static nl.knaw.huc.resources.HeaderLink.Uri.FILE;
+
+/**
+ * Post a file to ./fields with the request body containing the file contents
+ * and the Content-Type header containing the original mimetype
+ */
+public class OriginalIndexerFieldsRequest implements IndexerFieldsRequest {
+
+  private final String url;
+  private final Client client;
+
+  public OriginalIndexerFieldsRequest(String url, Client client) {
+    this.url = url;
+    this.client = client;
+  }
+
+  @Override
+  public Response requestFields(
+      @Nonnull String contents,
+      @Nonnull String mimetype,
+      @Nonnull UUID fileId
+  ) {
+    return client
+        .target(url)
+        .request()
+        .header("Link", HeaderLink.create(ORIGINAL, FILE, fileId))
+        .post(entity(contents, mimetype));
+  }
+}

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/task/DeleteContents.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/task/DeleteContents.java
@@ -21,7 +21,7 @@ public class DeleteContents implements InTransactionRunner {
 
   @Override
   public void executeIn(Handle transaction) {
-    var savepoint = "delete-" + contentsSha;
+    final var savepoint = "delete-" + contentsSha;
     transaction.savepoint(savepoint);
     try {
       transaction.attach(ContentsDao.class).delete(contentsSha);

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/task/DeleteContents.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/task/DeleteContents.java
@@ -21,11 +21,14 @@ public class DeleteContents implements InTransactionRunner {
 
   @Override
   public void executeIn(Handle transaction) {
+    var savepoint = "delete-" + contentsSha;
+    transaction.savepoint(savepoint);
     try {
       transaction.attach(ContentsDao.class).delete(contentsSha);
     } catch (JdbiException ex) {
       if (violatesConstraint(ex, VERSIONS_CONTENTS_SHA)) {
         log.debug("Not deleting contents because {} is still in use", contentsSha);
+        transaction.rollbackToSavepoint(savepoint);
       } else {
         throw (ex);
       }

--- a/textrepo-app/src/main/java/nl/knaw/huc/service/version/JdbiVersionService.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/version/JdbiVersionService.java
@@ -73,8 +73,13 @@ public class JdbiVersionService implements VersionService {
 
   @Override
   public Page<Version> getAll(UUID fileId, PageParams pageParams, LocalDateTime createdAfter) {
-    var items = versions().findByFileId(fileId, pageParams, createdAfter);
     var total = versions().countByFileId(fileId, createdAfter);
+    if (total == 0) {
+      if (jdbi.onDemand(FilesDao.class).find(fileId).isEmpty()) {
+        throw new NotFoundException(format("No file with ID %s", fileId));
+      }
+    }
+    var items = versions().findByFileId(fileId, pageParams, createdAfter);
     return new Page<>(items, total, pageParams);
   }
 

--- a/textrepo-app/src/test/java/nl/knaw/huc/resources/rest/DocumentFilesResourceTest.java
+++ b/textrepo-app/src/test/java/nl/knaw/huc/resources/rest/DocumentFilesResourceTest.java
@@ -1,0 +1,132 @@
+package nl.knaw.huc.resources.rest;
+
+import com.jayway.jsonpath.JsonPath;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import nl.knaw.huc.PaginationConfiguration;
+import nl.knaw.huc.core.Document;
+import nl.knaw.huc.core.TextRepoFile;
+import nl.knaw.huc.db.DocumentFilesDao;
+import nl.knaw.huc.db.DocumentsDao;
+import nl.knaw.huc.helpers.Paginator;
+import nl.knaw.huc.service.datetime.LocalDateTimeParamConverterProvider;
+import nl.knaw.huc.service.document.files.DocumentFilesService;
+import nl.knaw.huc.service.document.files.JdbiDocumentFilesService;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class DocumentFilesResourceTest {
+
+  private static final UUID documentUuid = UUID.fromString("0defaced-cafe-babe-dada-deadbeefc2c6");
+  private static final Document document = new Document(documentUuid, "external-id");
+
+  private static final Jdbi jdbi = mock(Jdbi.class);
+
+  private static final int TEST_LIMIT = 10;
+  private static final int TEST_OFFSET = 0;
+  private static final Paginator paginator = createPaginator();
+
+  private static Paginator createPaginator() {
+    var config = new PaginationConfiguration();
+    config.defaultOffset = TEST_OFFSET;
+    config.defaultLimit = TEST_LIMIT;
+    return new Paginator(config);
+  }
+
+  private static final DocumentFilesService documentFilesService = new JdbiDocumentFilesService(jdbi);
+
+  // Don't forget to setup and reset mocks:
+  private static final DocumentsDao DOCUMENTS_DAO = mock(DocumentsDao.class);
+  private static final DocumentFilesDao DOCUMENT_FILES_DAO = mock(DocumentFilesDao.class);
+
+  // With milliseconds:
+  private static final String dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+
+  public static final ResourceExtension resource;
+
+  static {
+
+    resource = ResourceExtension
+        .builder()
+        .addProvider(MultiPartFeature.class)
+        .addProvider(() -> new LocalDateTimeParamConverterProvider(dateFormat))
+        .addResource(new DocumentFilesResource(documentFilesService, paginator))
+        .build();
+  }
+
+  @BeforeEach
+  public void setupMocks() {
+    when(jdbi.onDemand(DocumentsDao.class)).thenReturn(DOCUMENTS_DAO);
+    when(jdbi.onDemand(DocumentFilesDao.class)).thenReturn(DOCUMENT_FILES_DAO);
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @AfterEach
+  public void resetMocks() {
+    reset(jdbi, DOCUMENT_FILES_DAO, DOCUMENTS_DAO);
+  }
+
+  @Test
+  public void testGetDocumentFiles_returnsFilesPage() {
+    List<TextRepoFile> files = new ArrayList<>();
+    var file1 = new TextRepoFile(UUID.randomUUID(), (short) 1);
+    files.add(file1);
+    var file2 = new TextRepoFile(UUID.randomUUID(), (short) 2);
+    files.add(file2);
+    when(DOCUMENT_FILES_DAO.findFilesByDocumentId(any(), any())).thenReturn(files);
+    when(DOCUMENT_FILES_DAO.countByDocumentId(any())).thenReturn(2L);
+
+    var response = resource
+        .client()
+        .target("/rest/documents/" + documentUuid.toString() + "/files")
+        .request()
+        .get();
+    verify(DOCUMENT_FILES_DAO, times(1)).findFilesByDocumentId(eq(documentUuid), any());
+    var actual = JsonPath.parse(response.readEntity(String.class));
+    assertThat(actual.read("$.items.length()", Integer.class)).isEqualTo(2);
+    assertThat(actual.read("$.total", Integer.class)).isEqualTo(2);
+    assertThat(actual.read("$.items[0].docId", String.class)).isEqualTo(documentUuid.toString());
+    assertThat(actual.read("$.items[0].id", String.class)).isEqualTo(file1.getId().toString());
+    assertThat(actual.read("$.items[1].docId", String.class)).isEqualTo(documentUuid.toString());
+    assertThat(actual.read("$.items[1].id", String.class)).isEqualTo(file2.getId().toString());
+  }
+
+  @Test
+  public void testGetDocumentFiles_returns404() {
+    when(DOCUMENT_FILES_DAO.findFilesByDocumentId(any(), any())).thenReturn(new ArrayList<>());
+    when(DOCUMENT_FILES_DAO.countByDocumentId(any())).thenReturn(0L);
+    when(DOCUMENTS_DAO.get(any())).thenReturn(Optional.empty());
+
+    var response = resource
+        .client()
+        .target("/rest/documents/" + documentUuid.toString() + "/files")
+        .request()
+        .get();
+
+    verify(DOCUMENT_FILES_DAO, times(0)).findFilesByDocumentId(eq(documentUuid), any());
+    var actual = JsonPath.parse(response.readEntity(String.class));
+    assertThat(response.getStatus()).isEqualTo(404);
+    assertThat(actual.read("$.message", String.class)).contains(documentUuid.toString());
+  }
+
+}

--- a/textrepo-app/src/test/java/nl/knaw/huc/resources/rest/FileVersionsResourceTest.java
+++ b/textrepo-app/src/test/java/nl/knaw/huc/resources/rest/FileVersionsResourceTest.java
@@ -5,7 +5,9 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import nl.knaw.huc.PaginationConfiguration;
 import nl.knaw.huc.core.PageParams;
+import nl.knaw.huc.core.TextRepoFile;
 import nl.knaw.huc.core.Version;
+import nl.knaw.huc.db.FilesDao;
 import nl.knaw.huc.db.VersionsDao;
 import nl.knaw.huc.helpers.Paginator;
 import nl.knaw.huc.service.contents.ContentsService;
@@ -26,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -41,7 +44,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class FileVersionsResourceTest {
 
-  private static final UUID uuid = UUID.fromString("0defaced-cafe-babe-dada-deadbeefc2c6");
+  private static final UUID fileUuid = UUID.fromString("0defaced-cafe-babe-dada-deadbeefc2c6");
+  private static final TextRepoFile file = new TextRepoFile(fileUuid, (short) 1);
 
   private static final Jdbi jdbi = mock(Jdbi.class);
 
@@ -63,9 +67,11 @@ public class FileVersionsResourceTest {
       UUID::randomUUID
   );
 
+  // Don't forget to setup and reset mocks:
   private static final VersionsDao VERSIONS_DAO = mock(VersionsDao.class);
+  private static final FilesDao FILES_DAO = mock(FilesDao.class);
 
-  // with milliseconds:
+  // With milliseconds:
   private static final String dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS";
 
   public static final ResourceExtension resource;
@@ -82,39 +88,60 @@ public class FileVersionsResourceTest {
 
   @BeforeEach
   public void setupMocks() {
-    when(jdbi.onDemand(any())).thenReturn(VERSIONS_DAO);
+    when(jdbi.onDemand(VersionsDao.class)).thenReturn(VERSIONS_DAO);
+    when(jdbi.onDemand(FilesDao.class)).thenReturn(FILES_DAO);
     MockitoAnnotations.initMocks(this);
   }
 
   @AfterEach
   public void resetMocks() {
-    reset(jdbi, VERSIONS_DAO);
+    reset(jdbi, VERSIONS_DAO, FILES_DAO);
   }
 
   @Test
   public void testGetVersions_returnsVersions() {
     List<Version> versions = new ArrayList<>();
     var sha1 = "fcd01d3b5648843931feb9ef4468250ac1a968a41add37f663af3bb0";
-    var version1 = new Version(UUID.randomUUID(), uuid, sha1, LocalDateTime.now());
+    var version1 = new Version(UUID.randomUUID(), fileUuid, sha1, LocalDateTime.now());
     versions.add(version1);
     var sha2 = "d476f2f6e00deaa918dfbec79545412134e02095f870269175b89376";
-    var version2 = new Version(UUID.randomUUID(), uuid, sha2, LocalDateTime.now());
+    var version2 = new Version(UUID.randomUUID(), fileUuid, sha2, LocalDateTime.now());
     versions.add(version2);
     when(VERSIONS_DAO.findByFileId(any(), any(PageParams.class), any())).thenReturn(versions);
+    when(VERSIONS_DAO.countByFileId(any(), any())).thenReturn(2L);
 
     var response = resource
         .client()
-        .target("/rest/files/" + uuid.toString() + "/versions")
+        .target("/rest/files/" + fileUuid.toString() + "/versions")
         .request()
         .get();
 
-    verify(VERSIONS_DAO, times(1)).findByFileId(eq(uuid), any(PageParams.class), any());
+    verify(VERSIONS_DAO, times(1)).findByFileId(eq(fileUuid), any(PageParams.class), any());
     var actual = JsonPath.parse(response.readEntity(String.class));
     assertThat(actual.read("$.items.length()", Integer.class)).isEqualTo(2);
-    assertThat(actual.read("$.items[0].fileId", String.class)).isEqualTo(uuid.toString());
+    assertThat(actual.read("$.total", Integer.class)).isEqualTo(2);
+    assertThat(actual.read("$.items[0].fileId", String.class)).isEqualTo(fileUuid.toString());
     assertThat(actual.read("$.items[0].contentsSha", String.class)).isEqualTo(sha1);
-    assertThat(actual.read("$.items[1].fileId", String.class)).isEqualTo(uuid.toString());
+    assertThat(actual.read("$.items[1].fileId", String.class)).isEqualTo(fileUuid.toString());
     assertThat(actual.read("$.items[1].contentsSha", String.class)).isEqualTo(sha2);
+  }
+
+  @Test
+  public void testGetVersions_returns404() {
+    when(VERSIONS_DAO.find(any())).thenReturn(Optional.empty());
+    when(VERSIONS_DAO.countByFileId(any(), any())).thenReturn(0L);
+    when(FILES_DAO.find(any())).thenReturn(Optional.empty());
+
+    var response = resource
+        .client()
+        .target("/rest/files/" + fileUuid.toString() + "/versions")
+        .request()
+        .get();
+
+    verify(VERSIONS_DAO, times(0)).findByFileId(eq(fileUuid), any(PageParams.class), any());
+    assertThat(response.getStatus()).isEqualTo(404);
+    var actual = JsonPath.parse(response.readEntity(String.class));
+    assertThat(actual.read("$.message", String.class)).contains(fileUuid.toString());
   }
 
   @Test
@@ -122,25 +149,26 @@ public class FileVersionsResourceTest {
     var past = new SimpleDateFormat(dateFormat).format(new Date());
     List<Version> versions = new ArrayList<>();
     var sha1 = "fcd01d3b5648843931feb9ef4468250ac1a968a41add37f663af3bb0";
-    var version1 = new Version(UUID.randomUUID(), uuid, sha1, LocalDateTime.now());
+    var version1 = new Version(UUID.randomUUID(), fileUuid, sha1, LocalDateTime.now());
     versions.add(version1);
     var sha2 = "d476f2f6e00deaa918dfbec79545412134e02095f870269175b89376";
-    var version2 = new Version(UUID.randomUUID(), uuid, sha2, LocalDateTime.now());
+    var version2 = new Version(UUID.randomUUID(), fileUuid, sha2, LocalDateTime.now());
     versions.add(version2);
     when(VERSIONS_DAO.findByFileId(any(), any(PageParams.class), any())).thenReturn(versions);
+    when(VERSIONS_DAO.countByFileId(any(), any())).thenReturn(2L);
 
     var response = resource
         .client()
-        .target("/rest/files/" + uuid.toString() + "/versions?createdAfter=" + past)
+        .target("/rest/files/" + fileUuid.toString() + "/versions?createdAfter=" + past)
         .request()
         .get();
 
-    verify(VERSIONS_DAO, times(1)).findByFileId(eq(uuid), any(PageParams.class), any());
+    verify(VERSIONS_DAO, times(1)).findByFileId(eq(fileUuid), any(PageParams.class), any());
     var actual = JsonPath.parse(response.readEntity(String.class));
     assertThat(actual.read("$.items.length()", Integer.class)).isEqualTo(2);
-    assertThat(actual.read("$.items[0].fileId", String.class)).isEqualTo(uuid.toString());
+    assertThat(actual.read("$.items[0].fileId", String.class)).isEqualTo(fileUuid.toString());
     assertThat(actual.read("$.items[0].contentsSha", String.class)).isEqualTo(sha1);
-    assertThat(actual.read("$.items[1].fileId", String.class)).isEqualTo(uuid.toString());
+    assertThat(actual.read("$.items[1].fileId", String.class)).isEqualTo(fileUuid.toString());
     assertThat(actual.read("$.items[1].contentsSha", String.class)).isEqualTo(sha2);
   }
 
@@ -150,7 +178,7 @@ public class FileVersionsResourceTest {
     var betweenVersions = new SimpleDateFormat(noSAndMs).format(new Date());
     var response = resource
         .client()
-        .target("/rest/files/" + uuid.toString() + "/versions?createdAfter=" + betweenVersions)
+        .target("/rest/files/" + fileUuid.toString() + "/versions?createdAfter=" + betweenVersions)
         .request()
         .get();
 


### PR DESCRIPTION
Problem: A request to this task to delete a document returns a 500 when some of its file version contents cannot be deleted.
Solution: At first signt this problem should not occur, since we already seem to handle the foreign key containt that checks contents can only be deleted when not referenced by any versions (`versions_contents_sha_fkey`). However, catching the exception is not enough: we need to rollback the transaction to the point before adding the statement that violates `versions_contents_sha_fkey`.