### PR TITLE
Change statuscode for REST CREATE calls from 200 OK to 201 Created

### DIFF
--- a/concordion/src/test/resources/nl/knaw/huc/textrepo/rest/TestRestDocuments.md
+++ b/concordion/src/test/resources/nl/knaw/huc/textrepo/rest/TestRestDocuments.md
@@ -15,7 +15,7 @@ When creating the following document with a `POST` to [`/rest/documents`](- "#cr
 
 Then:
 
- - The response status should be: [200](- "?=#createResult.status");
+ - The response status should be: [201](- "?=#createResult.status");
  - The response should contain a [valid UUID](- "?=#createResult.validUuid");
  - Full response:
  

--- a/concordion/src/test/resources/nl/knaw/huc/textrepo/rest/TestRestFiles.md
+++ b/concordion/src/test/resources/nl/knaw/huc/textrepo/rest/TestRestFiles.md
@@ -19,7 +19,7 @@ When creating the following file with a `POST` to [`/rest/files`](- "#createEndp
 
 Then:
 
- - The response status should be: [200](- "?=#createResult.status");
+ - The response status should be: [201](- "?=#createResult.status");
  - The response should contain a [valid UUID](- "?=#createResult.validUuid");
  - Full response:
  

--- a/concordion/src/test/resources/nl/knaw/huc/textrepo/rest/TestRestTypes.md
+++ b/concordion/src/test/resources/nl/knaw/huc/textrepo/rest/TestRestTypes.md
@@ -14,7 +14,7 @@ When creating the following type with a `POST` to [`/rest/types`](- "#createEndp
 
 Then:
 
- - The response status should be: [200](- "?=#createResult.status");
+ - The response status should be: [201](- "?=#createResult.status");
  - The response should contain a [valid ID](- "?=#createResult.hasId");
  - Full response:
  

--- a/concordion/src/test/resources/nl/knaw/huc/textrepo/rest/TestRestVersions.md
+++ b/concordion/src/test/resources/nl/knaw/huc/textrepo/rest/TestRestVersions.md
@@ -19,7 +19,7 @@ When creating the following version with a `POST` to [`/rest/versions`](- "#crea
 
 Then:
 
- - The response status should be: [200](- "?=#createResult.status");
+ - The response status should be: [201](- "?=#createResult.status");
  - The response should contain a [valid UUID](- "?=#createResult.validUuid");
  - Full response:
  

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentsResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/DocumentsResource.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static nl.knaw.huc.helpers.Paginator.toResult;
+import static nl.knaw.huc.resources.HeaderLink.Uri.DOCUMENT;
 
 @Api(tags = {"documents"})
 @Path("/rest/documents")
@@ -54,14 +55,17 @@ public class DocumentsResource {
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create document")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultDocument.class, message = "OK")})
+  @ApiResponses(value = {@ApiResponse(code = 201, response = ResultDocument.class, message = "Created")})
   public Response createDocument(
       @Valid FormDocument form
   ) {
     log.debug("Create document: {}", form);
     var doc = documentService.create(new Document(null, form.getExternalId()));
     log.debug("Created document: {}", doc);
-    return Response.ok(new ResultDocument(doc)).build();
+    return Response
+        .created(DOCUMENT.build(doc.getId()))
+        .entity(new ResultDocument(doc))
+        .build();
   }
 
   @GET

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/FilesResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/FilesResource.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static nl.knaw.huc.resources.HeaderLink.Uri.FILE;
 
 @Api(tags = {"files"})
 @Path("/rest/files")
@@ -44,14 +45,17 @@ public class FilesResource {
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create file")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultTextRepoFile.class, message = "OK")})
+  @ApiResponses(value = {@ApiResponse(code = 201, response = ResultTextRepoFile.class, message = "Created")})
   public Response createFile(
       @Valid FormTextRepoFile form
   ) {
     log.debug("Create file: form={}", form);
     var file = fileService.insert(form.getDocId(), new TextRepoFile(null, form.getTypeId()));
     log.debug("Created file: {}", file);
-    return Response.ok(new ResultTextRepoFile(form.getDocId(), file)).build();
+    return Response
+        .created(FILE.build(file.getId()))
+        .entity(new ResultTextRepoFile(form.getDocId(), file))
+        .build();
   }
 
   @GET

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/TypesResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/TypesResource.java
@@ -26,6 +26,7 @@ import javax.ws.rs.core.Response;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static nl.knaw.huc.resources.HeaderLink.Uri.TYPE;
 
 @Api(tags = {"types"})
 @Path("/rest/types")
@@ -43,7 +44,7 @@ public class TypesResource {
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create type")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultType.class, message = "OK")})
+  @ApiResponses(value = {@ApiResponse(code = 201, response = ResultType.class, message = "Created")})
   public Response createType(
       @Valid @NotNull FormType form
   ) {
@@ -51,7 +52,10 @@ public class TypesResource {
     log.debug("Create type: type={}", type);
     var created = typeService.create(type);
     log.debug("Created type: {}", created);
-    return Response.ok(new ResultType(created)).build();
+    return Response
+        .created(TYPE.build(created.getId()))
+        .entity(new ResultType(created))
+        .build();
   }
 
   @GET

--- a/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/VersionsResource.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/resources/rest/VersionsResource.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
+import static nl.knaw.huc.resources.HeaderLink.Uri.FILE_VERSIONS;
 import static nl.knaw.huc.resources.ResourceUtils.readContents;
 
 @Api(tags = {"versions"})
@@ -50,7 +51,7 @@ public class VersionsResource {
   @Consumes(MULTIPART_FORM_DATA)
   @Produces(APPLICATION_JSON)
   @ApiOperation(value = "Create version")
-  @ApiResponses(value = {@ApiResponse(code = 200, response = ResultVersion.class, message = "OK")})
+  @ApiResponses(value = {@ApiResponse(code = 201, response = ResultVersion.class, message = "Created")})
   public Response createVersion(
       @FormDataParam("fileId") UUID fileId,
       @FormDataParam("contents") InputStream inputStream
@@ -59,7 +60,10 @@ public class VersionsResource {
     var contents = readContents(inputStream);
     var version = versionService.createNewVersion(fileId, contents);
     log.debug("Created version: {}", version);
-    return Response.ok(new ResultVersion(version)).build();
+    return Response
+        .created(FILE_VERSIONS.build(version.getId()))
+        .entity(new ResultVersion(version))
+        .build();
   }
 
   @GET

--- a/textrepo-app/src/test/java/nl/knaw/huc/resources/rest/TypesResourceTest.java
+++ b/textrepo-app/src/test/java/nl/knaw/huc/resources/rest/TypesResourceTest.java
@@ -14,6 +14,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
 
+import java.net.URI;
+
 import static javax.ws.rs.client.Entity.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -63,7 +65,8 @@ public class TypesResourceTest {
         .request()
         .post(json(form));
 
-    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getStatus()).isEqualTo(201);
+    assertThat(response.getLocation()).isEqualTo(URI.create("http://localhost:0/rest/types/456"));
 
     verify(typeService, times(1)).create(typeCaptor.capture());
     var toCreate = typeCaptor.getValue();


### PR DESCRIPTION
POSTs to: 
- `/rest/documents`
- `/rest/files`
- `/rest/types`
- `/rest/versions`
Would return statuscode `200 OK`
These changes makes them return `201 Created` instead

See:
https://datatracker.ietf.org/doc/html/rfc7231#section-6.3.2
https://restfulapi.net/http-status-201-created/