### PR TITLE
Keep Type.name if Type.id is same during update

### DIFF
--- a/textrepo-app/src/main/java/nl/knaw/huc/service/type/JdbiTypeService.java
+++ b/textrepo-app/src/main/java/nl/knaw/huc/service/type/JdbiTypeService.java
@@ -81,7 +81,8 @@ public class JdbiTypeService implements TypeService {
   }
 
   private void throwWhenNameExists(@Nonnull Type type) {
-    if (types().exists(type.getName())) {
+    final var existingId = types().findByName(type.getName());
+    if (existingId.isPresent() && existingId.get() != type.getId()) {
       throw new WebApplicationException("Duplicate type name: " + type.getName(), CONFLICT);
     }
   }


### PR DESCRIPTION
When trying to change the mimetype of a given type, `/rest/types/{id}` requires both name and mimetype.

If we use the original type name (since we don't want to change that), the PUT returns a Duplicate type name error

Accept existing typeName when typeIds match.